### PR TITLE
Fix RoboEyes header include paths

### DIFF
--- a/src/eyes.cpp
+++ b/src/eyes.cpp
@@ -1,4 +1,4 @@
-#include "robo_eyes/robo_eyes.hpp"
+#include "robofer/eyes.hpp"
 #include <opencv2/imgproc.hpp>
 #include <algorithm>
 

--- a/src/eyes_node.cpp
+++ b/src/eyes_node.cpp
@@ -1,7 +1,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>
-#include "robo_eyes/robo_eyes.hpp"
+#include "robofer/eyes.hpp"
 
 using robo_eyes::RoboEyes; using robo_eyes::Mood; using robo_eyes::Pos;
 


### PR DESCRIPTION
## Summary
- fix include paths to use robofer/eyes.hpp in simulation library and node

## Testing
- `colcon test` *(fails: command not found)*
- `cmake ..` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_689a22faac088321a9600684c08a06a3