### PR TITLE
Declare rosidl interface package group

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,7 +20,8 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-    <export>
+
+  <export>
     <build_type>ament_cmake</build_type>
     <member_of_group>rosidl_interface_packages</member_of_group>
   </export>


### PR DESCRIPTION
## Summary
- ensure package is marked as an interface provider for ROS 2

## Testing
- `source /opt/ros/humble/setup.bash && colcon build --packages-select robofer` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a248c7a5c8321904dda7af65fb9ab