### PR TITLE
Add eyes menu system with physical and keyboard buttons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ target_link_libraries(robo_eyes_st7735_node
 # 3.3) Nodo unificado (elige backend por parámetro: sim | st7735)
 add_executable(eyes_unified_node
   src/eyes_unified_node.cpp
+  src/ui_menu.cpp
 )
 ament_target_dependencies(eyes_unified_node rclcpp std_msgs)
 target_link_libraries(eyes_unified_node
@@ -94,6 +95,19 @@ target_link_libraries(eyes_unified_node
   robo_display
   ${OpenCV_LIBS}
 )
+
+# --- Botones físicos ---
+add_executable(buttons_node
+  src/buttons.cpp
+)
+ament_target_dependencies(buttons_node rclcpp std_msgs)
+target_link_libraries(buttons_node gpiod)
+
+# --- Botones por teclado (simulación) ---
+add_executable(keyboard_buttons_node
+  src/keyboard_buttons.cpp
+)
+ament_target_dependencies(keyboard_buttons_node rclcpp std_msgs)
 
 # =========================================
 # 4) Instalación
@@ -116,12 +130,19 @@ install(TARGETS
   robo_eyes_sim
   robo_eyes_st7735_node
   eyes_unified_node
+  buttons_node
+  keyboard_buttons_node
   DESTINATION lib/${PROJECT_NAME}
 )
 
 # Headers
 install(DIRECTORY include/
   DESTINATION include
+)
+
+# Launch files
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
 )
 
 # =========================================

--- a/include/robofer/ui_menu.hpp
+++ b/include/robofer/ui_menu.hpp
@@ -1,0 +1,71 @@
+#pragma once
+#include <opencv2/core.hpp>
+#include <string>
+#include <vector>
+#include <functional>
+#include <chrono>
+
+namespace robo_ui {
+
+// Eventos de navegación desde los botones
+enum class UiKey : int { UP=0, DOWN=1, BACK=2, OK=3 };
+
+// Acciones que el menú puede solicitar al mundo exterior
+enum class MenuAction {
+  NONE,
+  SET_ANGRY,
+  SET_SAD,
+  SET_HAPPY,
+  POWEROFF,
+};
+
+// Controlador de menú: mantiene estructura y estado; dibuja sobre canvas 8UC1
+class MenuController {
+public:
+  explicit MenuController(std::function<void(MenuAction)> on_action);
+
+  void on_key(UiKey key);       // recibe teclas, reinicia TTL
+  bool is_active() const;       // se muestra si hubo pulsación en timeout_ms
+  void draw(cv::Mat& canvas);   // dibuja overlay si activo
+
+  void set_timeout_ms(int ms);  // por defecto 5000
+  void set_font_scale(double s);// tamaño de fuente OpenCV (0.4 por defecto)
+
+private:
+  struct Item {
+    std::string label;
+    bool is_submenu{false};
+    MenuAction action{MenuAction::NONE};
+    std::vector<Item> children;
+  };
+
+  static Item build_default_tree();
+
+  // navegación
+  std::vector<int> path_;
+  int sel_{0};
+  const Item* current_menu() const;
+  Item* current_menu();
+
+  void enter();
+  void back();
+  void up();
+  void down();
+  void dispatch(MenuAction a);
+
+  // dibujo
+  void draw_panel(cv::Mat& canvas);
+  void draw_header(cv::Mat& img, const std::string& title, int x, int y, int w);
+  void draw_items(cv::Mat& img, const std::vector<Item>& items, int x, int y, int w, int line_h);
+
+  Item root_;
+  std::function<void(MenuAction)> on_action_;
+  int timeout_ms_{5000};
+  double font_scale_{0.45};
+
+  using clock = std::chrono::steady_clock;
+  clock::time_point last_key_time_;
+};
+
+} // namespace robo_ui
+

--- a/launch/eyes_system.launch.py
+++ b/launch/eyes_system.launch.py
@@ -1,0 +1,142 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch.conditions import IfCondition, UnlessCondition
+
+def generate_launch_description():
+    sim = LaunchConfiguration('sim')
+
+    eyes_width  = LaunchConfiguration('eyes_width')
+    eyes_height = LaunchConfiguration('eyes_height')
+    fps         = LaunchConfiguration('fps')
+    menu_timeout_ms = LaunchConfiguration('menu_timeout_ms')
+
+    spi_device  = LaunchConfiguration('spi_device')
+    spi_hz      = LaunchConfiguration('spi_hz')
+    use_manual_cs = LaunchConfiguration('use_manual_cs')
+    gpiochip_c  = LaunchConfiguration('gpiochip_c')
+    dc_offset   = LaunchConfiguration('dc_offset')
+    rst_offset  = LaunchConfiguration('rst_offset')
+    cs_offset   = LaunchConfiguration('cs_offset')
+    spi_chunk   = LaunchConfiguration('spi_chunk')
+    madctl      = LaunchConfiguration('madctl')
+    invert      = LaunchConfiguration('invert')
+    self_test   = LaunchConfiguration('self_test')
+
+    btn1_offset = LaunchConfiguration('btn1_offset')
+    btn2_offset = LaunchConfiguration('btn2_offset')
+    btn3_offset = LaunchConfiguration('btn3_offset')
+    btn4_offset = LaunchConfiguration('btn4_offset')
+
+    eyes_node_sim = Node(
+        package='robofer',
+        executable='eyes_unified_node',
+        name='eyes_unified_node',
+        output='screen',
+        parameters=[{
+            'backend': 'sim',
+            'eyes_width': eyes_width,
+            'eyes_height': eyes_height,
+            'fps': fps,
+            'menu_timeout_ms': menu_timeout_ms,
+        }]
+    )
+
+    eyes_node_hw = Node(
+        package='robofer',
+        executable='eyes_unified_node',
+        name='eyes_unified_node',
+        output='screen',
+        parameters=[{
+            'backend': 'st7735',
+            'eyes_width': eyes_width,
+            'eyes_height': eyes_height,
+            'fps': fps,
+            'menu_timeout_ms': menu_timeout_ms,
+            'spi_device': spi_device,
+            'spi_hz': spi_hz,
+            'use_manual_cs': use_manual_cs,
+            'gpiochip_c': gpiochip_c,
+            'dc_offset': dc_offset,
+            'rst_offset': rst_offset,
+            'cs_offset': cs_offset,
+            'spi_chunk': spi_chunk,
+            'madctl': madctl,
+            'invert': invert,
+            'self_test': self_test,
+        }]
+    )
+
+    keyboard_node = Node(
+        package='robofer',
+        executable='keyboard_buttons_node',
+        name='keyboard_buttons_node',
+        output='screen',
+        parameters=[{
+            'key_up': 'w',
+            'key_down': 's',
+            'key_back': 'a',
+            'key_ok': 'd',
+            'repeat_ms': 0,
+        }]
+    )
+
+    buttons_node = Node(
+        package='robofer',
+        executable='buttons_node',
+        name='buttons_node',
+        output='screen',
+        parameters=[{
+            'gpiochip': gpiochip_c,
+            'rising_on_press': True,
+            'debounce_ms': 150,
+            'btn1_offset': btn1_offset,
+            'btn2_offset': btn2_offset,
+            'btn3_offset': btn3_offset,
+            'btn4_offset': btn4_offset,
+            'btn1_code': 0,
+            'btn2_code': 1,
+            'btn3_code': 2,
+            'btn4_code': 3,
+        }]
+    )
+
+    ld = LaunchDescription()
+
+    ld.add_action(DeclareLaunchArgument('sim', default_value='true'))
+
+    ld.add_action(DeclareLaunchArgument('eyes_width', default_value='128'))
+    ld.add_action(DeclareLaunchArgument('eyes_height', default_value='64'))
+    ld.add_action(DeclareLaunchArgument('fps', default_value='30'))
+    ld.add_action(DeclareLaunchArgument('menu_timeout_ms', default_value='5000'))
+
+    ld.add_action(DeclareLaunchArgument('spi_device', default_value='/dev/spidev1.0'))
+    ld.add_action(DeclareLaunchArgument('spi_hz', default_value='24000000'))
+    ld.add_action(DeclareLaunchArgument('use_manual_cs', default_value='true'))
+    ld.add_action(DeclareLaunchArgument('gpiochip_c', default_value='gpiochip0'))
+    ld.add_action(DeclareLaunchArgument('dc_offset', default_value='75'))
+    ld.add_action(DeclareLaunchArgument('rst_offset', default_value='78'))
+    ld.add_action(DeclareLaunchArgument('cs_offset', default_value='233'))
+    ld.add_action(DeclareLaunchArgument('spi_chunk', default_value='2048'))
+    ld.add_action(DeclareLaunchArgument('madctl', default_value='0'))
+    ld.add_action(DeclareLaunchArgument('invert', default_value='false'))
+    ld.add_action(DeclareLaunchArgument('self_test', default_value='true'))
+
+    ld.add_action(DeclareLaunchArgument('btn1_offset', default_value='-1'))
+    ld.add_action(DeclareLaunchArgument('btn2_offset', default_value='-1'))
+    ld.add_action(DeclareLaunchArgument('btn3_offset', default_value='-1'))
+    ld.add_action(DeclareLaunchArgument('btn4_offset', default_value='-1'))
+
+    eyes_node_sim.condition = IfCondition(sim)
+    eyes_node_hw.condition = UnlessCondition(sim)
+    keyboard_node.condition = IfCondition(sim)
+    buttons_node.condition = UnlessCondition(sim)
+
+    ld.add_action(eyes_node_sim)
+    ld.add_action(eyes_node_hw)
+    ld.add_action(keyboard_node)
+    ld.add_action(buttons_node)
+
+    return ld
+

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,8 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
   <build_depend>rclcpp</build_depend>
   <exec_depend>rclcpp</exec_depend>
+  <build_depend>std_msgs</build_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <!-- OpenCV from system -->
   <build_depend>opencv</build_depend>

--- a/src/buttons.cpp
+++ b/src/buttons.cpp
@@ -1,0 +1,153 @@
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/int32.hpp>
+#include <gpiod.h>
+#include <chrono>
+#include <thread>
+#include <atomic>
+#include <vector>
+#include <string>
+#include <memory>
+
+using namespace std::chrono_literals;
+
+struct ButtonWatcher {
+  std::string chip_name{"gpiochip0"};
+  int offset{-1};
+  int ui_code{0};
+  bool rising_on_press{true};
+  int debounce_ms{150};
+
+  rclcpp::Logger logger;
+  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr pub;
+
+  gpiod_chip* chip{nullptr};
+  gpiod_line* line{nullptr};
+  std::thread th;
+  std::atomic<bool> running{false};
+
+  ButtonWatcher(rclcpp::Node& node,
+                const std::string& chip,
+                int off, int code, bool rising, int debounce,
+                rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr publisher)
+  : chip_name(chip), offset(off), ui_code(code), rising_on_press(rising),
+    debounce_ms(debounce), logger(node.get_logger()), pub(std::move(publisher)) {}
+
+  ~ButtonWatcher(){ stop(); }
+
+  bool start(){
+    if(offset < 0) return true;
+    chip = gpiod_chip_open_by_name(chip_name.c_str());
+    if(!chip){
+      RCLCPP_ERROR(logger, "gpiod_chip_open_by_name('%s') fallo", chip_name.c_str());
+      return false;
+    }
+    line = gpiod_chip_get_line(chip, offset);
+    if(!line){
+      RCLCPP_ERROR(logger, "gpiod_chip_get_line(offset=%d) fallo", offset);
+      return false;
+    }
+    unsigned flags = 0;
+    int rc = rising_on_press
+      ? gpiod_line_request_rising_edge_events_flags(line, "buttons_node", flags)
+      : gpiod_line_request_falling_edge_events_flags(line, "buttons_node", flags);
+    if(rc < 0){
+      RCLCPP_ERROR(logger, "gpiod_line_request_*_events(offset=%d) fallo", offset);
+      return false;
+    }
+
+    running = true;
+    th = std::thread([this]{
+      using clock = std::chrono::steady_clock;
+      auto last_emit = clock::now() - std::chrono::milliseconds(debounce_ms);
+      while(running.load()){
+        timespec ts{1,0};
+        int wait_rc = gpiod_line_event_wait(line, &ts);
+        if(wait_rc <= 0) continue;
+        gpiod_line_event ev{};
+        if(gpiod_line_event_read(line, &ev) < 0){
+          RCLCPP_WARN(logger, "gpiod_line_event_read fallo (offset=%d)", offset);
+          continue;
+        }
+        bool press = false;
+        if(rising_on_press && ev.event_type == GPIOD_LINE_EVENT_RISING_EDGE) press = true;
+        if(!rising_on_press && ev.event_type == GPIOD_LINE_EVENT_FALLING_EDGE) press = true;
+        if(press){
+          auto now = clock::now();
+          if(now - last_emit >= std::chrono::milliseconds(debounce_ms)){
+            last_emit = now;
+            std_msgs::msg::Int32 m; m.data = ui_code;
+            pub->publish(m);
+            RCLCPP_INFO(logger, "Btn offset=%d -> /ui/button=%d", offset, ui_code);
+          }
+        }
+      }
+    });
+
+    RCLCPP_INFO(logger, "Watcher: chip=%s offset=%d ui_code=%d rising=%s debounce=%dms",
+                chip_name.c_str(), offset, ui_code, rising_on_press?"true":"false", debounce_ms);
+    return true;
+  }
+
+  void stop(){
+    if(!running.exchange(false)) return;
+    if(th.joinable()) th.join();
+    if(line){ gpiod_line_release(line); line=nullptr; }
+    if(chip){ gpiod_chip_close(chip); chip=nullptr; }
+  }
+};
+
+class ButtonsNode : public rclcpp::Node {
+public:
+  ButtonsNode() : Node("buttons_node")
+  {
+    const auto chip   = this->declare_parameter<std::string>("gpiochip", "gpiochip0");
+    const bool rising = this->declare_parameter<bool>("rising_on_press", true);
+    const int  debounce = this->declare_parameter<int>("debounce_ms", 150);
+
+    const int btn1_off = this->declare_parameter<int>("btn1_offset", -1);
+    const int btn2_off = this->declare_parameter<int>("btn2_offset", -1);
+    const int btn3_off = this->declare_parameter<int>("btn3_offset", -1);
+    const int btn4_off = this->declare_parameter<int>("btn4_offset", -1);
+
+    const int btn1_code = this->declare_parameter<int>("btn1_code", 0);
+    const int btn2_code = this->declare_parameter<int>("btn2_code", 1);
+    const int btn3_code = this->declare_parameter<int>("btn3_code", 2);
+    const int btn4_code = this->declare_parameter<int>("btn4_code", 3);
+
+    pub_ = this->create_publisher<std_msgs::msg::Int32>("/ui/button", 10);
+
+    auto make = [&](int off, int code){
+      return std::make_unique<ButtonWatcher>(*this, chip, off, code, rising, debounce, pub_);
+    };
+
+    watchers_.emplace_back(make(btn1_off, btn1_code));
+    watchers_.emplace_back(make(btn2_off, btn2_code));
+    watchers_.emplace_back(make(btn3_off, btn3_code));
+    watchers_.emplace_back(make(btn4_off, btn4_code));
+
+    bool ok = true;
+    for(auto& w : watchers_){
+      if(w->offset >= 0) ok = w->start() && ok;
+    }
+    if(!ok){
+      RCLCPP_FATAL(this->get_logger(), "Fallo inicializando botones. Revisa gpiochip/offsets.");
+      throw std::runtime_error("buttons init failed");
+    }
+    RCLCPP_INFO(this->get_logger(), "ButtonsNode listo. Publica /ui/button (0=UP,1=DOWN,2=BACK,3=OK).");
+  }
+
+private:
+  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr pub_;
+  std::vector<std::unique_ptr<ButtonWatcher>> watchers_;
+};
+
+int main(int argc, char** argv){
+  rclcpp::init(argc, argv);
+  try {
+    auto n = std::make_shared<ButtonsNode>();
+    rclcpp::spin(n);
+  } catch(...) {}
+  rclcpp::shutdown();
+  return 0;
+}
+

--- a/src/keyboard_buttons.cpp
+++ b/src/keyboard_buttons.cpp
@@ -1,0 +1,112 @@
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/int32.hpp>
+#include <termios.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <cstring>
+#include <thread>
+#include <atomic>
+#include <unordered_map>
+
+class RawTerminalGuard {
+public:
+  RawTerminalGuard(){
+    tcgetattr(STDIN_FILENO, &orig_);
+    termios raw = orig_;
+    raw.c_lflag &= ~(ICANON | ECHO);
+    raw.c_cc[VMIN] = 0;
+    raw.c_cc[VTIME] = 0;
+    tcsetattr(STDIN_FILENO, TCSANOW, &raw);
+  }
+  ~RawTerminalGuard(){ tcsetattr(STDIN_FILENO, TCSANOW, &orig_); }
+private:
+  termios orig_{};
+};
+
+class KeyboardButtonsNode : public rclcpp::Node {
+public:
+  KeyboardButtonsNode() : Node("keyboard_buttons_node")
+  {
+    key_up_   = this->declare_parameter<std::string>("key_up", "w");
+    key_down_ = this->declare_parameter<std::string>("key_down", "s");
+    key_back_ = this->declare_parameter<std::string>("key_back", "a");
+    key_ok_   = this->declare_parameter<std::string>("key_ok", "d");
+    repeat_ms_= this->declare_parameter<int>("repeat_ms", 0);
+
+    pub_ = this->create_publisher<std_msgs::msg::Int32>("/ui/button", 10);
+
+    map_[norm(key_up_)]   = 0;
+    map_[norm(key_down_)] = 1;
+    map_[norm(key_back_)] = 2;
+    map_[norm(key_ok_)]   = 3;
+
+    RCLCPP_INFO(this->get_logger(),
+      "Teclado activo: [%s]=UP(0), [%s]=DOWN(1), [%s]=BACK(2), [%s]=OK(3), repeat_ms=%d",
+      key_up_.c_str(), key_down_.c_str(), key_back_.c_str(), key_ok_.c_str(), repeat_ms_);
+
+    running_.store(true);
+    th_ = std::thread([this]{ this->loop(); });
+  }
+
+  ~KeyboardButtonsNode() override {
+    running_.store(false);
+    if(th_.joinable()) th_.join();
+  }
+
+private:
+  std::string key_up_, key_down_, key_back_, key_ok_;
+  int repeat_ms_{0};
+  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr pub_;
+  std::thread th_;
+  std::atomic<bool> running_{false};
+  std::unordered_map<int,int> map_;
+
+  static int norm(const std::string& s){
+    if(s.empty()) return 0;
+    return static_cast<int>(::tolower(s[0]) & 0xFF);
+  }
+
+  void loop(){
+    RawTerminalGuard rtg;
+    auto last_sent = std::unordered_map<int, rclcpp::Time>{};
+    while(rclcpp::ok() && running_.load()){
+      fd_set rfds; FD_ZERO(&rfds); FD_SET(STDIN_FILENO, &rfds);
+      timeval tv{0,20000};
+      int rv = select(STDIN_FILENO+1, &rfds, nullptr, nullptr, &tv);
+      if(rv > 0 && FD_ISSET(STDIN_FILENO, &rfds)){
+        char c; ssize_t n = ::read(STDIN_FILENO, &c, 1);
+        if(n == 1){
+          int code = static_cast<int>(::tolower(c) & 0xFF);
+          auto it = map_.find(code);
+          if(it != map_.end()){
+            int ui_code = it->second;
+            auto now = this->now();
+            bool can_send = true;
+            if(repeat_ms_ > 0){
+              auto jt = last_sent.find(code);
+              if(jt != last_sent.end()){
+                auto dt = (now - jt->second).nanoseconds() / 1000000;
+                can_send = dt >= repeat_ms_;
+              }
+            }
+            if(can_send){
+              std_msgs::msg::Int32 m; m.data = ui_code;
+              pub_->publish(m);
+              last_sent[code] = now;
+              RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
+                "Key '%c' -> /ui/button=%d", c, ui_code);
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+int main(int argc, char** argv){
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<KeyboardButtonsNode>());
+  rclcpp::shutdown();
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
- Implement UI menu overlay supporting mode changes and poweroff
- Add button and keyboard input nodes with launch file for simulation vs hardware
- Update unified eyes node to render menu and respond to menu actions

## Testing
- `colcon build --packages-select robofer` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ef1aa7308321908b81aaa5cd031b