### PR TITLE
Improve menu overlay for RoboEyes

### DIFF
--- a/src/eyes_unified_node.cpp
+++ b/src/eyes_unified_node.cpp
@@ -3,6 +3,7 @@
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
 #include <mutex>
+#include <algorithm>
 
 #include "robofer/eyes.hpp"
 #include "robofer/display.hpp"
@@ -72,7 +73,6 @@ int main(int argc, char** argv){
   ActionDispatcher dispatch{ log, eyes };
   MenuController   menu([&](MenuAction a){ dispatch(a); });
   menu.set_timeout_ms(menu_timeout_ms);
-  menu.set_font_scale(0.45);
 
   std::mutex ui_mtx;
   auto sub_ui = node->create_subscription<std_msgs::msg::Int32>(
@@ -90,6 +90,7 @@ int main(int argc, char** argv){
 
   int DW = display->width();   if(DW <= 0) DW = eyes_w;
   int DH = display->height();  if(DH <= 0) DH = eyes_h;
+  menu.set_font_scale(std::clamp(DH / 100.0, 0.4, 1.0));
   cv::Mat canvas(DH, DW, CV_8UC1, cv::Scalar(0));
 
   while(rclcpp::ok()){

--- a/src/ui_menu.cpp
+++ b/src/ui_menu.cpp
@@ -107,17 +107,18 @@ void MenuController::draw_panel(cv::Mat& canvas){
   const int pad = std::max(4, W/64);
   const int panel_w = std::min(W - 2*pad, std::max(80, W*3/5));
   const int panel_h = std::min(H - 2*pad, std::max(60, H*3/5));
-  const int x = pad, y = pad;
+  const int x = (W - panel_w) / 2;
+  const int y = (H - panel_h) / 2;
 
   cv::Mat roi = canvas(cv::Rect(x, y, panel_w, panel_h));
-  roi = cv::max(roi, 40);
+  roi.setTo(cv::Scalar(40));
 
   cv::rectangle(canvas, cv::Rect(x, y, panel_w, panel_h), cv::Scalar(200), 1, cv::LINE_8);
 
   const Item* menu = current_menu();
   draw_header(canvas, menu->label, x, y, panel_w);
 
-  int line_h = std::max(12, H/14);
+  int line_h = std::max(12, panel_h / ((int)menu->children.size() + 2));
   draw_items(canvas, menu->children, x, y + line_h + 4, panel_w, line_h);
 }
 


### PR DESCRIPTION
## Summary
- Center menu panel and give it a solid background for better readability
- Scale menu font according to display height

## Testing
- `colcon build` *(fails: command not found)*
- `mkdir -p build && cd build && cmake ..` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a70604220483219611dd37c5ad9ee7