### PR TITLE
Scale menu to screen and add scroll support

### DIFF
--- a/include/robofer/ui_menu.hpp
+++ b/include/robofer/ui_menu.hpp
@@ -44,6 +44,7 @@ private:
   // navegación
   std::vector<int> path_;
   int sel_{0};
+  int offset_{0};
   const Item* current_menu() const;
   Item* current_menu();
 
@@ -56,7 +57,8 @@ private:
   // dibujo
   void draw_panel(cv::Mat& canvas);
   void draw_header(cv::Mat& img, const std::string& title, int x, int y, int w);
-  void draw_items(cv::Mat& img, const std::vector<Item>& items, int x, int y, int w, int line_h);
+  void draw_items(cv::Mat& img, const std::vector<Item>& items, int x, int y,
+                  int w, int line_h, int start, int max_items);
 
   Item root_;
   std::function<void(MenuAction)> on_action_;


### PR DESCRIPTION
## Summary
- Ajusta el ancho y alto del panel según el texto y tamaño de pantalla
- Calcula altura de línea por tamaño de fuente
- Permite desplazamiento de elementos si no caben en pantalla

## Testing
- `colcon build --packages-select robofer` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a83a2b9890832190f9dc51601dd11f