### PR TITLE
Refactor naming conventions and document display factory

### DIFF
--- a/include/robofer/display.hpp
+++ b/include/robofer/display.hpp
@@ -20,6 +20,7 @@ public:
 };
 
 // Fábrica: backend="sim" | "st7735"
-std::unique_ptr<Display> make_display(const std::string& backend);
+// Crea el backend de salida de vídeo correspondiente.
+std::unique_ptr<Display> makeDisplay(const std::string& backend);
 
 } // namespace robo_eyes

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -357,7 +357,7 @@ private:
   GpioLine dc_, rst_, cs_;
 };
 
-std::unique_ptr<Display> make_display(const std::string& backend){
+std::unique_ptr<Display> makeDisplay(const std::string& backend){
   if(backend == "sim")     return std::make_unique<DisplaySim>();
   if(backend == "st7735")  return std::make_unique<DisplayST7735>();
   // por defecto, sim para que funcione en PC


### PR DESCRIPTION
## Summary
- use camelCase for `makeDisplay` factory
- rename internal variables in eyes node to snake_case and trailing underscores for attributes
- add brief documentation for menu action dispatcher and display factory

## Testing
- `colcon test` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package python3-colcon-common-extensions)*

------
https://chatgpt.com/codex/tasks/task_e_68a83cbfd88c8321a1f971a989dec892