### PR TITLE
Add servo control and state handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,18 @@ target_link_libraries(robo_display
 )
 
 # =========================================
+# Servos library
+# =========================================
+add_library(robo_servos
+  src/servos.cpp
+)
+target_include_directories(robo_servos PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(robo_servos gpiod)
+
+# =========================================
 # 3) Ejecutables
 # =========================================
 
@@ -109,6 +121,15 @@ add_executable(keyboard_buttons_node
 )
 ament_target_dependencies(keyboard_buttons_node rclcpp std_msgs)
 
+# --- State handler (modes + servos) ---
+add_executable(state_handler_node
+  src/state_handler_node.cpp
+)
+ament_target_dependencies(state_handler_node rclcpp std_msgs)
+target_link_libraries(state_handler_node
+  robo_servos
+)
+
 # =========================================
 # 4) Instalación
 #    - Librerías a lib/
@@ -120,6 +141,7 @@ ament_target_dependencies(keyboard_buttons_node rclcpp std_msgs)
 install(TARGETS
   robo_eyes_lib
   robo_display
+  robo_servos
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -132,6 +154,7 @@ install(TARGETS
   eyes_unified_node
   buttons_node
   keyboard_buttons_node
+  state_handler_node
   DESTINATION lib/${PROJECT_NAME}
 )
 
@@ -149,7 +172,7 @@ install(DIRECTORY launch
 # 5) Export para consumidores
 # =========================================
 ament_export_include_directories(include)
-ament_export_libraries(robo_eyes_lib robo_display)
+ament_export_libraries(robo_eyes_lib robo_display robo_servos)
 ament_export_dependencies(rclcpp OpenCV rosidl_default_runtime)
 
 ament_package()

--- a/include/robofer/servos.hpp
+++ b/include/robofer/servos.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <gpiod.h>
+#include <thread>
+#include <atomic>
+#include <string>
+#include <vector>
+
+namespace robo_servos {
+
+class ControlServo {
+public:
+  ControlServo(const std::string& chip_name, int servo1_offset, int servo2_offset);
+  ~ControlServo();
+
+  // continuous speed in degrees per second (positive = clockwise)
+  void set_speed(int id, float deg_per_sec);
+
+  // move until target angle reached at given speed (deg per second)
+  void move_to(int id, float angle_deg, float speed_deg_per_sec);
+
+  // stop any motion
+  void stop(int id);
+
+  // return to idle (angle 0)
+  void set_idle(int id);
+
+private:
+  struct Servo {
+    gpiod_line* line{nullptr};
+    std::thread th;
+    std::atomic<bool> running{false};
+    std::atomic<float> current_angle{0.0f};
+    std::atomic<float> target_angle{0.0f};
+    std::atomic<float> speed{0.0f};
+    std::atomic<bool> has_target{false};
+  };
+
+  gpiod_chip* chip_{nullptr};
+  std::vector<Servo> servos_;
+
+  void thread_func(Servo& s);
+};
+
+} // namespace robo_servos
+

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,9 @@
   <build_depend>std_msgs</build_depend>
   <exec_depend>std_msgs</exec_depend>
 
+  <build_depend>gpiod</build_depend>
+  <exec_depend>gpiod</exec_depend>
+
   <!-- OpenCV from system -->
   <build_depend>opencv</build_depend>
   <exec_depend>opencv</exec_depend>

--- a/src/servos.cpp
+++ b/src/servos.cpp
@@ -1,0 +1,97 @@
+#include "robofer/servos.hpp"
+#include <chrono>
+#include <cmath>
+#include <algorithm>
+
+using namespace std::chrono_literals;
+
+namespace robo_servos {
+
+ControlServo::ControlServo(const std::string& chip_name, int s1, int s2) {
+  chip_ = gpiod_chip_open_by_name(chip_name.c_str());
+  if(!chip_) throw std::runtime_error("gpiod_chip_open_by_name failed");
+  servos_.resize(2);
+  int offs[2] = {s1, s2};
+  for(int i=0;i<2;i++){
+    if(offs[i] < 0) continue;
+    servos_[i].line = gpiod_chip_get_line(chip_, offs[i]);
+    if(!servos_[i].line) throw std::runtime_error("gpiod_chip_get_line failed");
+    if(gpiod_line_request_output(servos_[i].line, "servo", 0) < 0)
+      throw std::runtime_error("gpiod_line_request_output failed");
+    servos_[i].running = true;
+    servos_[i].th = std::thread([this,i]{ thread_func(servos_[i]); });
+  }
+}
+
+ControlServo::~ControlServo(){
+  for(auto& s : servos_){
+    if(s.running){
+      s.running = false;
+      if(s.th.joinable()) s.th.join();
+    }
+    if(s.line){
+      gpiod_line_set_value(s.line, 0);
+      gpiod_line_release(s.line);
+    }
+  }
+  if(chip_) gpiod_chip_close(chip_);
+}
+
+void ControlServo::set_speed(int id, float deg_per_sec){
+  if(id < 0 || id >= (int)servos_.size()) return;
+  servos_[id].speed = deg_per_sec;
+  servos_[id].has_target = false;
+}
+
+void ControlServo::move_to(int id, float angle_deg, float speed_deg_per_sec){
+  if(id < 0 || id >= (int)servos_.size()) return;
+  servos_[id].target_angle = angle_deg;
+  servos_[id].speed = std::abs(speed_deg_per_sec);
+  servos_[id].has_target = true;
+}
+
+void ControlServo::stop(int id){
+  if(id < 0 || id >= (int)servos_.size()) return;
+  servos_[id].speed = 0.0f;
+  servos_[id].has_target = false;
+}
+
+void ControlServo::set_idle(int id){
+  move_to(id, 0.0f, 90.0f);
+}
+
+void ControlServo::thread_func(Servo& s){
+  using clock = std::chrono::steady_clock;
+  const float min_pw = 1000.0f; // microseconds
+  const float max_pw = 2000.0f; // microseconds
+  while(s.running){
+    auto start = clock::now();
+    float ang = s.current_angle.load();
+    if(s.has_target){
+      float tgt = s.target_angle.load();
+      float step = s.speed.load() * 0.02f; // 20ms frame
+      if(std::fabs(tgt - ang) <= step){
+        ang = tgt;
+        s.has_target = false;
+        s.speed = 0.0f;
+      } else {
+        ang += (tgt > ang ? 1.f : -1.f) * step;
+      }
+      s.current_angle = ang;
+    } else {
+      ang += s.speed.load() * 0.02f;
+      s.current_angle = ang;
+    }
+    float clamped = std::clamp(ang, 0.0f, 180.0f);
+    float pw = min_pw + (clamped / 180.0f) * (max_pw - min_pw);
+    gpiod_line_set_value(s.line, 1);
+    std::this_thread::sleep_for(std::chrono::microseconds((int)pw));
+    gpiod_line_set_value(s.line, 0);
+    auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(clock::now() - start);
+    auto sleep = std::chrono::microseconds(20000) - elapsed;
+    if(sleep.count() > 0) std::this_thread::sleep_for(sleep);
+  }
+}
+
+} // namespace robo_servos
+

--- a/src/state_handler_node.cpp
+++ b/src/state_handler_node.cpp
@@ -1,0 +1,62 @@
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/empty.hpp>
+#include <std_msgs/msg/uint8.hpp>
+
+#include "robofer/servos.hpp"
+#include "robofer/eyes.hpp"
+
+using robo_servos::ControlServo;
+using robo_eyes::Mood;
+
+class StateHandler : public rclcpp::Node {
+public:
+  StateHandler()
+  : Node("state_handler"),
+    servos_(this->declare_parameter<std::string>("gpiochip", "gpiochip0"),
+            this->declare_parameter<int>("servo1_offset", -1),
+            this->declare_parameter<int>("servo2_offset", -1))
+  {
+    mood_pub_ = this->create_publisher<std_msgs::msg::UInt8>("/eyes/mood", 10);
+
+    sub_happy_ = this->create_subscription<std_msgs::msg::Empty>(
+      "/mode/happy", 10, [&](const std_msgs::msg::Empty&){ handle_mode(Mood::HAPPY); });
+    sub_angry_ = this->create_subscription<std_msgs::msg::Empty>(
+      "/mode/angry", 10, [&](const std_msgs::msg::Empty&){ handle_mode(Mood::ANGRY); });
+    sub_sad_ = this->create_subscription<std_msgs::msg::Empty>(
+      "/mode/sad", 10, [&](const std_msgs::msg::Empty&){ handle_mode(Mood::FROWN); });
+  }
+
+private:
+  ControlServo servos_;
+  rclcpp::Publisher<std_msgs::msg::UInt8>::SharedPtr mood_pub_;
+  rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr sub_happy_, sub_angry_, sub_sad_;
+
+  void handle_mode(Mood m){
+    std_msgs::msg::UInt8 msg; msg.data = static_cast<uint8_t>(m);
+    mood_pub_->publish(msg);
+    switch(m){
+      case Mood::HAPPY:
+        servos_.set_speed(0, 90.0f);
+        servos_.set_speed(1,-90.0f);
+        break;
+      case Mood::ANGRY:
+        servos_.move_to(0, 30.0f, 120.0f);
+        servos_.move_to(1,150.0f, 120.0f);
+        break;
+      case Mood::FROWN:
+      default:
+        servos_.set_idle(0);
+        servos_.set_idle(1);
+        break;
+    }
+  }
+};
+
+int main(int argc, char** argv){
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<StateHandler>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
- add ControlServo class and state_handler node to manage dual servos
- publish menu mood changes to /mode/* topics and let state_handler update eyes
- expose servo library in build system

## Testing
- `colcon build --packages-select robofer` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ac07416e208321bac4b443c4c6c9f9