### PR TITLE
Implement state machine-based mode handler

### DIFF
--- a/include/robofer/state_handler.hpp
+++ b/include/robofer/state_handler.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/uint8.hpp>
+
+#include "robofer/servos.hpp"
+#include "robofer/eyes.hpp"
+
+namespace robofer {
+
+using robo_servos::ControlServo;
+using robo_eyes::Mood;
+
+class StateHandler : public rclcpp::Node {
+public:
+  StateHandler();
+
+private:
+  class State {
+  public:
+    virtual ~State() = default;
+    virtual void on_enter(StateHandler &ctx) {}
+    virtual void on_update(StateHandler &ctx) {}
+    virtual void on_exit(StateHandler &ctx) {}
+  };
+
+  class HappyState;
+  class AngryState;
+  class SadState;
+
+  friend class HappyState;
+  friend class AngryState;
+  friend class SadState;
+
+  void set_state(Mood m);
+  void mode_callback(const std_msgs::msg::UInt8::SharedPtr msg);
+  void update();
+
+  ControlServo servos_;
+  rclcpp::Publisher<std_msgs::msg::UInt8>::SharedPtr mood_pub_;
+  rclcpp::Subscription<std_msgs::msg::UInt8>::SharedPtr mode_sub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  std::unique_ptr<State> current_state_;
+};
+
+} // namespace robofer
+

--- a/src/state_handler_node.cpp
+++ b/src/state_handler_node.cpp
@@ -1,58 +1,91 @@
-#include <rclcpp/rclcpp.hpp>
-#include <std_msgs/msg/empty.hpp>
-#include <std_msgs/msg/uint8.hpp>
+#include <functional>
+#include <chrono>
+#include "robofer/state_handler.hpp"
 
-#include "robofer/servos.hpp"
-#include "robofer/eyes.hpp"
+using namespace std::chrono_literals;
 
-using robo_servos::ControlServo;
-using robo_eyes::Mood;
+namespace robofer {
 
-class StateHandler : public rclcpp::Node {
+// --- State implementations -------------------------------------------------
+
+class StateHandler::HappyState : public StateHandler::State {
 public:
-  StateHandler()
-  : Node("state_handler"),
-    servos_(this->declare_parameter<std::string>("gpiochip", "gpiochip0"),
-            this->declare_parameter<int>("servo1_offset", -1),
-            this->declare_parameter<int>("servo2_offset", -1))
-  {
-    mood_pub_ = this->create_publisher<std_msgs::msg::UInt8>("/eyes/mood", 10);
-
-    sub_happy_ = this->create_subscription<std_msgs::msg::Empty>(
-      "/mode/happy", 10, [&](const std_msgs::msg::Empty&){ handle_mode(Mood::HAPPY); });
-    sub_angry_ = this->create_subscription<std_msgs::msg::Empty>(
-      "/mode/angry", 10, [&](const std_msgs::msg::Empty&){ handle_mode(Mood::ANGRY); });
-    sub_sad_ = this->create_subscription<std_msgs::msg::Empty>(
-      "/mode/sad", 10, [&](const std_msgs::msg::Empty&){ handle_mode(Mood::FROWN); });
-  }
-
-private:
-  ControlServo servos_;
-  rclcpp::Publisher<std_msgs::msg::UInt8>::SharedPtr mood_pub_;
-  rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr sub_happy_, sub_angry_, sub_sad_;
-
-  void handle_mode(Mood m){
-    std_msgs::msg::UInt8 msg; msg.data = static_cast<uint8_t>(m);
-    mood_pub_->publish(msg);
-    switch(m){
-      case Mood::HAPPY:
-        servos_.set_speed(0, 90.0f);
-        servos_.set_speed(1,-90.0f);
-        break;
-      case Mood::ANGRY:
-        servos_.move_to(0, 30.0f, 120.0f);
-        servos_.move_to(1,150.0f, 120.0f);
-        break;
-      case Mood::FROWN:
-      default:
-        servos_.set_idle(0);
-        servos_.set_idle(1);
-        break;
-    }
+  void on_enter(StateHandler &ctx) override {
+    std_msgs::msg::UInt8 msg; msg.data = static_cast<uint8_t>(Mood::HAPPY);
+    ctx.mood_pub_->publish(msg);
+    ctx.servos_.set_speed(0, 90.0f);
+    ctx.servos_.set_speed(1,-90.0f);
   }
 };
 
-int main(int argc, char** argv){
+class StateHandler::AngryState : public StateHandler::State {
+public:
+  void on_enter(StateHandler &ctx) override {
+    std_msgs::msg::UInt8 msg; msg.data = static_cast<uint8_t>(Mood::ANGRY);
+    ctx.mood_pub_->publish(msg);
+    ctx.servos_.move_to(0, 30.0f, 120.0f);
+    ctx.servos_.move_to(1,150.0f, 120.0f);
+  }
+};
+
+class StateHandler::SadState : public StateHandler::State {
+public:
+  void on_enter(StateHandler &ctx) override {
+    std_msgs::msg::UInt8 msg; msg.data = static_cast<uint8_t>(Mood::FROWN);
+    ctx.mood_pub_->publish(msg);
+    ctx.servos_.set_idle(0);
+    ctx.servos_.set_idle(1);
+  }
+};
+
+} // namespace robofer
+
+using robofer::StateHandler;
+
+// --- StateHandler methods ---------------------------------------------------
+
+StateHandler::StateHandler()
+: Node("state_handler"),
+  servos_(declare_parameter<std::string>("gpiochip", "gpiochip0"),
+          declare_parameter<int>("servo1_offset", -1),
+          declare_parameter<int>("servo2_offset", -1))
+{
+  mood_pub_ = create_publisher<std_msgs::msg::UInt8>("/eyes/mood", 10);
+  mode_sub_ = create_subscription<std_msgs::msg::UInt8>(
+      "/mode", 10,
+      std::bind(&StateHandler::mode_callback, this, std::placeholders::_1));
+  timer_ = create_wall_timer(50ms, std::bind(&StateHandler::update, this));
+  set_state(Mood::FROWN);
+}
+
+void StateHandler::update() {
+  if (current_state_) current_state_->on_update(*this);
+}
+
+void StateHandler::mode_callback(const std_msgs::msg::UInt8::SharedPtr msg) {
+  set_state(static_cast<Mood>(msg->data));
+}
+
+void StateHandler::set_state(Mood m) {
+  if (current_state_) current_state_->on_exit(*this);
+  switch (m) {
+    case Mood::HAPPY:
+      current_state_ = std::make_unique<HappyState>();
+      break;
+    case Mood::ANGRY:
+      current_state_ = std::make_unique<AngryState>();
+      break;
+    case Mood::FROWN:
+    default:
+      current_state_ = std::make_unique<SadState>();
+      break;
+  }
+  current_state_->on_enter(*this);
+}
+
+// --- main ------------------------------------------------------------------
+
+int main(int argc, char **argv) {
   rclcpp::init(argc, argv);
   auto node = std::make_shared<StateHandler>();
   rclcpp::spin(node);


### PR DESCRIPTION
## Summary
- Add `StateHandler` header and implement a simple state machine framework
- Replace multiple mode topics with a single `/mode` subscription
- Drive mood and servo actions from state classes for easy extensibility

## Testing
- `colcon build --packages-select robofer` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0d98307c8321be22639e25e7e11d