### PR TITLE
Add servo simulation mode and monitoring node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,10 @@ target_include_directories(robo_servos PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
+ament_target_dependencies(robo_servos rclcpp)
 target_link_libraries(robo_servos gpiod)
+rosidl_target_interfaces(robo_servos
+  ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
 # =========================================
 # 3) Ejecutables
@@ -130,6 +133,13 @@ target_link_libraries(state_handler_node
   robo_servos
 )
 
+add_executable(servo_monitor_node
+  src/servo_monitor_node.cpp
+)
+ament_target_dependencies(servo_monitor_node rclcpp)
+rosidl_target_interfaces(servo_monitor_node
+  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+
 # =========================================
 # 4) Instalación
 #    - Librerías a lib/
@@ -155,6 +165,7 @@ install(TARGETS
   buttons_node
   keyboard_buttons_node
   state_handler_node
+  servo_monitor_node
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/include/robofer/servos.hpp
+++ b/include/robofer/servos.hpp
@@ -6,11 +6,18 @@
 #include <string>
 #include <vector>
 
+#include <rclcpp/rclcpp.hpp>
+#include "robofer/msg/servo_goal.hpp"
+
 namespace robo_servos {
 
 class ControlServo {
 public:
-  ControlServo(const std::string& chip_name, int servo1_offset, int servo2_offset);
+  ControlServo(rclcpp::Node *node,
+               const std::string &chip_name,
+               int servo1_offset,
+               int servo2_offset,
+               bool sim = false);
   ~ControlServo();
 
   // continuous speed in degrees per second (positive = clockwise)
@@ -27,7 +34,8 @@ public:
 
 private:
   struct Servo {
-    gpiod_line* line{nullptr};
+    int id{0};
+    gpiod_line *line{nullptr};
     std::thread th;
     std::atomic<bool> running{false};
     std::atomic<float> current_angle{0.0f};
@@ -36,10 +44,12 @@ private:
     std::atomic<bool> has_target{false};
   };
 
-  gpiod_chip* chip_{nullptr};
+  gpiod_chip *chip_{nullptr};
   std::vector<Servo> servos_;
+  bool sim_{false};
+  rclcpp::Publisher<robofer::msg::ServoGoal>::SharedPtr angle_pub_;
 
-  void thread_func(Servo& s);
+  void thread_func(Servo &s);
 };
 
 } // namespace robo_servos

--- a/src/servo_monitor_node.cpp
+++ b/src/servo_monitor_node.cpp
@@ -1,0 +1,36 @@
+#include <array>
+#include <rclcpp/rclcpp.hpp>
+#include "robofer/msg/servo_goal.hpp"
+using std::placeholders::_1;
+
+class ServoMonitor : public rclcpp::Node {
+public:
+  ServoMonitor() : Node("servo_monitor") {
+    sub_ = create_subscription<robofer::msg::ServoGoal>(
+        "servo_angles", 10,
+        std::bind(&ServoMonitor::angle_callback, this, _1));
+    timer_ = create_wall_timer(
+        std::chrono::milliseconds(500),
+        std::bind(&ServoMonitor::print_angles, this));
+  }
+private:
+  void angle_callback(const robofer::msg::ServoGoal::SharedPtr msg) {
+    if(msg->id >= 0 && msg->id < static_cast<int>(angles_.size()))
+      angles_[msg->id] = msg->angle;
+  }
+  void print_angles() {
+    RCLCPP_INFO(get_logger(), "Servo0: %.2f deg | Servo1: %.2f deg",
+                angles_[0], angles_[1]);
+  }
+  std::array<float,2> angles_{0.0f,0.0f};
+  rclcpp::Subscription<robofer::msg::ServoGoal>::SharedPtr sub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+int main(int argc, char **argv){
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<ServoMonitor>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/servos.cpp
+++ b/src/servos.cpp
@@ -7,34 +7,48 @@ using namespace std::chrono_literals;
 
 namespace robo_servos {
 
-ControlServo::ControlServo(const std::string& chip_name, int s1, int s2) {
-  chip_ = gpiod_chip_open_by_name(chip_name.c_str());
-  if(!chip_) throw std::runtime_error("gpiod_chip_open_by_name failed");
+ControlServo::ControlServo(rclcpp::Node *node,
+                           const std::string &chip_name,
+                           int s1, int s2,
+                           bool sim) {
+  sim_ = sim;
+  if(node) {
+    angle_pub_ = node->create_publisher<robofer::msg::ServoGoal>("servo_angles", 10);
+  }
   servos_.resize(2);
-  int offs[2] = {s1, s2};
   for(int i=0;i<2;i++){
-    if(offs[i] < 0) continue;
-    servos_[i].line = gpiod_chip_get_line(chip_, offs[i]);
-    if(!servos_[i].line) throw std::runtime_error("gpiod_chip_get_line failed");
-    if(gpiod_line_request_output(servos_[i].line, "servo", 0) < 0)
-      throw std::runtime_error("gpiod_line_request_output failed");
-    servos_[i].running = true;
-    servos_[i].th = std::thread([this,i]{ thread_func(servos_[i]); });
+    servos_[i].id = i;
+  }
+  if(!sim_){
+    chip_ = gpiod_chip_open_by_name(chip_name.c_str());
+    if(!chip_) throw std::runtime_error("gpiod_chip_open_by_name failed");
+    int offs[2] = {s1, s2};
+    for(int i=0;i<2;i++){
+      if(offs[i] < 0) continue;
+      servos_[i].line = gpiod_chip_get_line(chip_, offs[i]);
+      if(!servos_[i].line) throw std::runtime_error("gpiod_chip_get_line failed");
+      if(gpiod_line_request_output(servos_[i].line, "servo", 0) < 0)
+        throw std::runtime_error("gpiod_line_request_output failed");
+    }
+  }
+  for(auto &s : servos_){
+    s.running = true;
+    s.th = std::thread([this,&s]{ thread_func(s); });
   }
 }
 
 ControlServo::~ControlServo(){
-  for(auto& s : servos_){
+  for(auto &s : servos_){
     if(s.running){
       s.running = false;
       if(s.th.joinable()) s.th.join();
     }
-    if(s.line){
+    if(!sim_ && s.line){
       gpiod_line_set_value(s.line, 0);
       gpiod_line_release(s.line);
     }
   }
-  if(chip_) gpiod_chip_close(chip_);
+  if(!sim_ && chip_) gpiod_chip_close(chip_);
 }
 
 void ControlServo::set_speed(int id, float deg_per_sec){
@@ -60,7 +74,7 @@ void ControlServo::set_idle(int id){
   move_to(id, 0.0f, 90.0f);
 }
 
-void ControlServo::thread_func(Servo& s){
+void ControlServo::thread_func(Servo &s){
   using clock = std::chrono::steady_clock;
   const float min_pw = 1000.0f; // microseconds
   const float max_pw = 2000.0f; // microseconds
@@ -82,11 +96,21 @@ void ControlServo::thread_func(Servo& s){
       ang += s.speed.load() * 0.02f;
       s.current_angle = ang;
     }
+
+    if(angle_pub_){
+      robofer::msg::ServoGoal msg;
+      msg.id = static_cast<int8_t>(s.id);
+      msg.angle = s.current_angle.load();
+      angle_pub_->publish(msg);
+    }
+
     float clamped = std::clamp(ang, 0.0f, 180.0f);
     float pw = min_pw + (clamped / 180.0f) * (max_pw - min_pw);
-    gpiod_line_set_value(s.line, 1);
-    std::this_thread::sleep_for(std::chrono::microseconds((int)pw));
-    gpiod_line_set_value(s.line, 0);
+    if(!sim_ && s.line){
+      gpiod_line_set_value(s.line, 1);
+      std::this_thread::sleep_for(std::chrono::microseconds((int)pw));
+      gpiod_line_set_value(s.line, 0);
+    }
     auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(clock::now() - start);
     auto sleep = std::chrono::microseconds(20000) - elapsed;
     if(sleep.count() > 0) std::this_thread::sleep_for(sleep);

--- a/src/state_handler_node.cpp
+++ b/src/state_handler_node.cpp
@@ -13,8 +13,8 @@ public:
   void on_enter(StateHandler &ctx) override {
     std_msgs::msg::UInt8 msg; msg.data = static_cast<uint8_t>(Mood::HAPPY);
     ctx.mood_pub_->publish(msg);
-    ctx.servos_.set_speed(0, 90.0f);
-    ctx.servos_.set_speed(1,-90.0f);
+    ctx.servos_.set_speed(0, 360.0f);
+    ctx.servos_.set_speed(1,-360.0f);
   }
 };
 
@@ -46,9 +46,11 @@ using robofer::StateHandler;
 
 StateHandler::StateHandler()
 : Node("state_handler"),
-  servos_(declare_parameter<std::string>("gpiochip", "gpiochip0"),
+  servos_(this,
+          declare_parameter<std::string>("gpiochip", "gpiochip0"),
           declare_parameter<int>("servo1_offset", -1),
-          declare_parameter<int>("servo2_offset", -1))
+          declare_parameter<int>("servo2_offset", -1),
+          declare_parameter<bool>("sim", false))
 {
   mood_pub_ = create_publisher<std_msgs::msg::UInt8>("/eyes/mood", 10);
   mode_sub_ = create_subscription<std_msgs::msg::UInt8>(


### PR DESCRIPTION
## Summary
- allow servos to run in simulation mode and publish angles instead of driving hardware
- add terminal node that monitors and prints servo angles
- spin servos continuously at 360 deg/s in happy state

## Testing
- `colcon build --packages-select robofer` *(fails: By not providing "Findament_cmake.cmake"...)*

------
https://chatgpt.com/codex/tasks/task_e_68ac31d3f28c8321992c1961df02540f