### PR TITLE
Ensure OpenCV headers are included during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
-include_directories(include)
+include_directories(include ${OpenCV_INCLUDE_DIRS})
 
 # ---- Mensajes (si no los usas en los nodos, igualmente exportamos runtime) ----
 rosidl_generate_interfaces(${PROJECT_NAME}


### PR DESCRIPTION
## Summary
- ensure OpenCV include paths are exported by CMake to fix missing `opencv2/core.hpp`

## Testing
- `colcon build --packages-select robofer` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac35ebc5d48321a70693c95c435060