### PR TITLE
Document headers with block-style Doxygen comments

### DIFF
--- a/include/robofer/audio_player.hpp
+++ b/include/robofer/audio_player.hpp
@@ -8,24 +8,86 @@
 
 namespace robo_audio {
 
+/**
+ * @brief Simple audio playback utility.
+ *
+ * AudioPlayer searches for audio files in provided directories and
+ * spawns an external player (e.g. `aplay`) to reproduce them. The
+ * component can run in simulation mode where playback is skipped but
+ * paths are still resolved.
+ */
 class AudioPlayer {
 public:
+  /**
+   * @brief Construct a new AudioPlayer.
+   * @param sim When true, no external process is launched.
+   */
   explicit AudioPlayer(bool sim = false);
+
+  /**
+   * @brief Destructor. Stops any running playback.
+   */
   ~AudioPlayer();
 
+  /**
+   * @brief Define directories where audio files are searched.
+   * @param paths List of directories to scan.
+   */
   void set_search_paths(const std::vector<std::string>& paths);
+
+  /**
+   * @brief Define file extensions that are considered audio files.
+   * @param exts Allowed filename suffixes.
+   */
   void set_extensions(const std::vector<std::string>& exts);
+
+  /**
+   * @brief Set ALSA device name used by the external player.
+   * @param dev Device identifier.
+   */
   void set_alsa_device(const std::string& dev);
 
+  /** @brief Rebuild the lookup table of available audio files. */
   void reindex();
 
+  /**
+   * @brief Start playback of an audio file.
+   * @param key_or_path Key or full path to the audio file.
+   * @return true if playback was started.
+   */
   bool play(const std::string& key_or_path);
+
+  /**
+   * @brief Stop current playback, if any.
+   */
   void stop();
+
+  /**
+   * @brief Check whether an audio file is currently playing.
+   * @return true if a child process is active.
+   */
   bool is_playing() const;
 
 private:
+  /**
+   * @brief Convert string to lowercase for case-insensitive matching.
+   * @param s Input string.
+   * @return Lowercase copy.
+   */
   std::string to_lower(std::string s) const;
+
+  /**
+   * @brief Resolve key or path to a concrete audio file on disk.
+   * @param s Key or path.
+   * @return Resolved path if found.
+   */
   std::optional<std::string> resolve_key_or_path(const std::string& s) const;
+
+  /**
+   * @brief Launch the external player process for the given file.
+   * @param filepath Path to audio file.
+   * @return true if process spawned.
+   */
   bool spawn_player(const std::string& filepath);
 
   std::vector<std::string> paths_;

--- a/include/robofer/display.hpp
+++ b/include/robofer/display.hpp
@@ -6,20 +6,50 @@
 
 namespace robo_eyes {
 
-// Interfaz común de salida de vídeo
+/**
+ * @brief Common interface for video output backends.
+ *
+ * Implementations provide a physical display or a simulation window that
+ * can render monochrome frames.
+ */
 class Display {
 public:
+  /**
+   * @brief Virtual destructor for proper cleanup.
+   */
   virtual ~Display() = default;
-  // Lee parámetros específicos del backend desde el mismo nodo y deja listo el dispositivo/ventana.
+
+  /**
+   * @brief Initialise the display backend using node parameters.
+   * @param node ROS node providing configuration.
+   * @return true on success.
+   */
   virtual bool init(rclcpp::Node& node) = 0;
-  // Ancho/alto del "lienzo" del display físico/ventana.
-  virtual int width()  const = 0;
+
+  /**
+   * @brief Width of the target canvas in pixels.
+   * @return Width in pixels.
+   */
+  virtual int width() const = 0;
+
+  /**
+   * @brief Height of the target canvas in pixels.
+   * @return Height in pixels.
+   */
   virtual int height() const = 0;
-  // Pinta un frame 8UC1 (0..255). Cada backend decide cómo centrar/llenar.
+
+  /**
+   * @brief Display a single 8-bit grayscale frame.
+   * @param mono8 Image to render.
+   */
   virtual void pushMono8(const cv::Mat& mono8) = 0;
 };
 
-// Fábrica: backend="sim" | "st7735"
+/**
+ * @brief Factory for display backends.
+ * @param backend Identifier of the backend ("sim" or "st7735").
+ * @return Unique pointer to the selected backend.
+ */
 std::unique_ptr<Display> make_display(const std::string& backend);
 
 } // namespace robo_eyes

--- a/include/robofer/eyes.hpp
+++ b/include/robofer/eyes.hpp
@@ -17,98 +17,323 @@
 namespace robo_eyes
 {
 
-// Colors (monochrome) — map to 8-bit gray: 0 or 255
-constexpr int BGCOLOR = 0;   // background/overlays
-constexpr int MAINCOLOR = 255; // drawings
+/** Colors (monochrome) — map to 8-bit gray: 0 or 255 */
+constexpr int BGCOLOR = 0;   /**< Background/overlays. */
+constexpr int MAINCOLOR = 255; /**< Drawings. */
 
-// Moods
+/** Mood presets used to adjust eye expression */
 enum Mood : uint8_t { DEFAULT = 0, TIRED = 1, ANGRY = 2, HAPPY = 3, FROWN = 4 };
 
-// Predefined positions
+/** Predefined gaze positions */
 enum Pos : uint8_t { CENTER=0, N=1, NE=2, E=3, SE=4, S=5, SW=6, W=7, NW=8 };
 
+/**
+ * @brief Animated cartoon eyes renderer.
+ *
+ * RoboEyes produces frames representing expressive eyes. The class manages
+ * timing, mood transitions and basic animations such as blinking or
+ * looking around.
+ */
 class RoboEyes
 {
 public:
+  /**
+   * @brief Construct the eye renderer.
+   */
   RoboEyes();
 
+  /**
+   * @brief Initialise canvas dimensions and frame rate.
+   * @param width Width of each eye canvas.
+   * @param height Height of each eye canvas.
+   * @param fps Desired frames per second.
+   */
   void begin(int width, int height, int fps);
 
-  // one tick: updates animation state and renders to internal canvas
+  /**
+   * @brief Update animation state and render to internal canvas.
+   */
   void update();
 
-  // current frame (CV_8UC1)
+  /**
+   * @brief Get current 8-bit frame.
+   * @return Rendered canvas.
+   */
   const cv::Mat& frame() const { return canvas_; }
 
   // setters
+  /**
+   * @brief Adjust target framerate.
+   * @param fps Desired frames per second.
+   */
   void setFramerate(int fps);
+  /**
+   * @brief Set eye dimensions.
+   * @param left_w Width of left eye.
+   * @param left_h Height of left eye.
+   * @param right_w Width of right eye.
+   * @param right_h Height of right eye.
+   */
   void setSize(int left_w, int left_h, int right_w, int right_h);
+  /**
+   * @brief Set corner radii for left and right eyes.
+   * @param left_r Radius for left eye corners.
+   * @param right_r Radius for right eye corners.
+   */
   void setBorderRadius(int left_r, int right_r);
+  /**
+   * @brief Space between eyes in pixels.
+   * @param px Separation distance.
+   */
   void setSpaceBetween(int px);
 
+  /**
+   * @brief Change overall mood expression.
+   * @param m Desired mood.
+   */
   void setMood(Mood m);
+  /**
+   * @brief Set gaze position.
+   * @param p New gaze position.
+   */
   void setPosition(Pos p);
 
+  /**
+   * @brief Configure automatic blinking behaviour.
+   * @param active Whether blinking is active.
+   * @param interval_s Base interval in seconds.
+   * @param variation_s Random variation in seconds.
+   */
   void setAutoblinker(bool active, int interval_s, int variation_s);
+  /**
+   * @brief Configure idle animation behaviour.
+   * @param active Whether idle behaviour is active.
+   * @param interval_s Base interval in seconds.
+   * @param variation_s Random variation in seconds.
+   */
   void setIdle(bool active, int interval_s, int variation_s);
+  /**
+   * @brief Enable or disable curious behaviour.
+   * @param on True to enable.
+   */
   void setCurious(bool on) { curious_ = on; }
+  /**
+   * @brief Render as a single cyclops eye when true.
+   * @param on True for single eye.
+   */
   void setCyclops(bool on) { cyclops_ = on; }
 
   // basic animations
+  /**
+   * @brief Close both eyes.
+   */
   void closeBoth();
+  /**
+   * @brief Open both eyes.
+   */
   void openBoth();
+  /**
+   * @brief Blink with both eyes.
+   */
   void blinkBoth();
 
   // macro (single-shot)
+  /**
+   * @brief Play "confused" animation once.
+   */
   void anim_confused();
+  /**
+   * @brief Play "laugh" animation once.
+   */
   void anim_laugh();
 
   // === Aliases con los nombres de la librería original ===
+  /**
+   * @brief Alias of setSize for backward compatibility.
+   * @param leftEye Width/height for left eye.
+   * @param rightEye Width/height for right eye.
+   */
   void setWidth(int leftEye, int rightEye);
+  /**
+   * @brief Alias of setSize for backward compatibility.
+   * @param leftEye Height for left eye.
+   * @param rightEye Height for right eye.
+   */
   void setHeight(int leftEye, int rightEye);
+  /**
+   * @brief Alias of setBorderRadius for backward compatibility.
+   * @param leftEye Radius for left eye.
+   * @param rightEye Radius for right eye.
+   */
   void setBorderradius(int leftEye, int rightEye);
+  /**
+   * @brief Alias of setSpaceBetween for backward compatibility.
+   * @param space Separation distance.
+   */
   void setSpacebetween(int space);
+  /**
+   * @brief Alias of setCurious.
+   * @param curiousBit Enable curiosity flag.
+   */
   void setCuriosity(bool curiousBit) { setCurious(curiousBit); }
 
   // === Overloads “cómodos” ===
-  void setAutoblinker(bool active);                 // usa valores actuales de s/var
-  void setIdle(bool active);                        // usa valores actuales de s/var
+  /**
+   * @brief Enable autoblinker using existing timing parameters.
+   * @param active Whether blinking is active.
+   */
+  void setAutoblinker(bool active);
+  /**
+   * @brief Enable idle behaviour using existing timing parameters.
+   * @param active Whether idle behaviour is active.
+   */
+  void setIdle(bool active);
 
   // === Control por ojo ===
-  void close();                                     // ambos
-  void open();                                      // ambos
-  void blink();                                     // ambos
+  /**
+   * @brief Close both eyes (alias).
+   */
+  void close();
+  /**
+   * @brief Open both eyes (alias).
+   */
+  void open();
+  /**
+   * @brief Blink both eyes (alias).
+   */
+  void blink();
+  /**
+   * @brief Close specific eyes.
+   * @param left Close left eye.
+   * @param right Close right eye.
+   */
   void close(bool left, bool right);
+  /**
+   * @brief Open specific eyes.
+   * @param left Open left eye.
+   * @param right Open right eye.
+   */
   void open(bool left, bool right);
+  /**
+   * @brief Blink specific eyes.
+   * @param left Blink left eye.
+   * @param right Blink right eye.
+   */
   void blink(bool left, bool right);
 
   // === Flickers directos ===
+  /**
+   * @brief Horizontal flicker with custom amplitude.
+   * @param flickerBit Enable flag.
+   * @param amplitude Flicker amplitude.
+   */
   void setHFlicker(bool flickerBit, int amplitude);
-  void setHFlicker(bool flickerBit);                // mantiene amp actual
+  /**
+   * @brief Horizontal flicker using current amplitude.
+   * @param flickerBit Enable flag.
+   */
+  void setHFlicker(bool flickerBit);
+  /**
+   * @brief Vertical flicker with custom amplitude.
+   * @param flickerBit Enable flag.
+   * @param amplitude Flicker amplitude.
+   */
   void setVFlicker(bool flickerBit, int amplitude);
-  void setVFlicker(bool flickerBit);                // mantiene amp actual
+  /**
+   * @brief Vertical flicker using current amplitude.
+   * @param flickerBit Enable flag.
+   */
+  void setVFlicker(bool flickerBit);
 
   // === Getters con el nombre original ===
+  /**
+   * @brief Get horizontal screen constraint.
+   * @return Constraint in pixels.
+   */
   int getScreenConstraint_X() const;
+  /**
+   * @brief Get vertical screen constraint.
+   * @return Constraint in pixels.
+   */
   int getScreenConstraint_Y() const;
     uint64_t frownFlickerLastChange_ = 0;
   int frownFlickerIntervalMs_ = 100; // cambia cada 100ms (~10 Hz)
 private:
   // time helpers
+  /**
+   * @brief Get current time in milliseconds.
+   * @return Timestamp in ms.
+   */
   static uint64_t now_ms();
+  /**
+   * @brief Generate a random integer in [0, max_inclusive].
+   * @param max_inclusive Maximum value.
+   * @return Random number.
+   */
   int rnd(int max_inclusive);
 
   // geometry helpers
+  /**
+   * @brief Horizontal screen constraint based on current layout.
+   * @return Constraint in pixels.
+   */
   int screenConstraintX() const;
+  /**
+   * @brief Vertical screen constraint based on current layout.
+   * @return Constraint in pixels.
+   */
   int screenConstraintY() const;
 
   // drawing helpers
+  /**
+   * @brief Clear image with a gray value.
+   * @param img Image to clear.
+   * @param gray Gray value.
+   */
   static void clear(cv::Mat& img, int gray=0);
+  /**
+   * @brief Draw a filled rounded rectangle.
+   * @param img Target image.
+   * @param x X coordinate.
+   * @param y Y coordinate.
+   * @param w Width.
+   * @param h Height.
+   * @param r Corner radius.
+   * @param gray Gray value.
+   */
   static void fillRoundRect(cv::Mat& img, int x, int y, int w, int h, int r, int gray);
+  /**
+   * @brief Draw a filled triangle.
+   * @param img Target image.
+   * @param a Vertex A.
+   * @param b Vertex B.
+   * @param c Vertex C.
+   * @param gray Gray value.
+   */
   static void fillTriangle(cv::Mat& img, cv::Point a, cv::Point b, cv::Point c, int gray);
+  /**
+   * @brief Draw a filled rectangle.
+   * @param img Target image.
+   * @param x X coordinate.
+   * @param y Y coordinate.
+   * @param w Width.
+   * @param h Height.
+   * @param gray Gray value.
+   */
   static void fillRect(cv::Mat& img, int x, int y, int w, int h, int gray);
+  /**
+   * @brief Draw a filled circle.
+   * @param img Target image.
+   * @param cx Center X.
+   * @param cy Center Y.
+   * @param r Radius.
+   * @param gray Gray value.
+   */
   static void fillCircle(cv::Mat& img, int cx, int cy, int r, int gray);
 
+  /**
+   * @brief Render the eyes into the internal canvas.
+   */
   void drawEyes();
 
 private:

--- a/include/robofer/servos.hpp
+++ b/include/robofer/servos.hpp
@@ -11,25 +11,59 @@
 
 namespace robo_servos {
 
+/**
+ * @brief Control interface for two hardware servomotors.
+ *
+ * The class wraps libgpiod access and provides simple speed and position
+ * commands for a pair of servos. It also publishes goal angles to a ROS
+ * topic for other components to monitor.
+ */
 class ControlServo {
 public:
+  /**
+   * @brief Construct a new ControlServo instance.
+   * @param node Parent ROS node.
+   * @param chip_name Name of the GPIO chip used to drive the servos.
+   * @param servo1_offset Offset applied to servo 1 neutral position.
+   * @param servo2_offset Offset applied to servo 2 neutral position.
+   * @param sim When true, no hardware access is performed.
+   */
   ControlServo(rclcpp::Node *node,
                const std::string &chip_name,
                int servo1_offset,
                int servo2_offset,
                bool sim = false);
+
+  /**
+   * @brief Destructor that stops control threads.
+   */
   ~ControlServo();
 
-  // continuous speed in degrees per second (positive = clockwise)
+  /**
+   * @brief Set continuous rotation speed for a servo.
+   * @param id Servo identifier.
+   * @param deg_per_sec Speed in degrees per second (positive = clockwise).
+   */
   void set_speed(int id, float deg_per_sec);
 
-  // move until target angle reached at given speed (deg per second)
+  /**
+   * @brief Move servo to a target angle at a given speed.
+   * @param id Servo identifier.
+   * @param angle_deg Target angle in degrees.
+   * @param speed_deg_per_sec Speed in degrees per second.
+   */
   void move_to(int id, float angle_deg, float speed_deg_per_sec);
 
-  // stop any motion
+  /**
+   * @brief Stop any motion on the specified servo.
+   * @param id Servo identifier.
+   */
   void stop(int id);
 
-  // return to idle (angle 0)
+  /**
+   * @brief Move servo back to the idle (zero) angle.
+   * @param id Servo identifier.
+   */
   void set_idle(int id);
 
 private:
@@ -49,6 +83,10 @@ private:
   bool sim_{false};
   rclcpp::Publisher<robofer::msg::ServoGoal>::SharedPtr angle_pub_;
 
+  /**
+   * @brief Worker thread that drives a single servo.
+   * @param s Servo control block.
+   */
   void thread_func(Servo &s);
 };
 

--- a/include/robofer/state_handler.hpp
+++ b/include/robofer/state_handler.hpp
@@ -13,19 +13,43 @@ namespace robofer {
 using robo_servos::ControlServo;
 using robo_eyes::Mood;
 
+/**
+ * @brief ROS node that manages robot moods and actions.
+ *
+ * StateHandler coordinates servos, eyes and audio feedback according to
+ * the current mood. It listens for mode requests and periodically
+ * updates the active state.
+ */
 class StateHandler : public rclcpp::Node {
 public:
+  /**
+   * @brief Construct the StateHandler node.
+   */
   StateHandler();
 
 private:
+  /** @brief Base class for concrete mood states. */
   class State {
   public:
     virtual ~State() = default;
+    /**
+     * @brief Called when the state becomes active.
+     * @param ctx Parent context.
+     */
     virtual void on_enter(StateHandler &ctx) {}
+    /**
+     * @brief Called periodically while the state is active.
+     * @param ctx Parent context.
+     */
     virtual void on_update(StateHandler &ctx) {}
+    /**
+     * @brief Called when the state is about to be replaced.
+     * @param ctx Parent context.
+     */
     virtual void on_exit(StateHandler &ctx) {}
   };
 
+  // Concrete states implementing different moods
   class HappyState;
   class AngryState;
   class SadState;
@@ -34,8 +58,21 @@ private:
   friend class AngryState;
   friend class SadState;
 
+  /**
+   * @brief Change the active mood/state.
+   * @param m Desired mood.
+   */
   void set_state(Mood m);
+
+  /**
+   * @brief Handle external mode requests from a topic.
+   * @param msg Incoming message with the desired mood.
+   */
   void mode_callback(const std_msgs::msg::UInt8::SharedPtr msg);
+
+  /**
+   * @brief Periodic update tick invoked by a timer.
+   */
   void update();
 
   ControlServo servos_;

--- a/include/robofer/ui_menu.hpp
+++ b/include/robofer/ui_menu.hpp
@@ -7,10 +7,14 @@
 
 namespace robo_ui {
 
-// Eventos de navegación desde los botones
+/**
+ * @brief Navigation events generated from physical buttons.
+ */
 enum class UiKey : int { UP=0, DOWN=1, BACK=2, OK=3 };
 
-// Acciones que el menú puede solicitar al mundo exterior
+/**
+ * @brief Actions that the menu can request from external components.
+ */
 enum class MenuAction {
   NONE,
   SET_ANGRY,
@@ -19,17 +23,50 @@ enum class MenuAction {
   POWEROFF,
 };
 
-// Controlador de menú: mantiene estructura y estado; dibuja sobre canvas 8UC1
+/**
+ * @brief Menu controller responsible for navigation and drawing.
+ *
+ * MenuController maintains a menu tree, reacts to key events and renders
+ * itself as an overlay onto an 8-bit grayscale canvas. The menu becomes
+ * inactive after a configurable timeout without user interaction.
+ */
 class MenuController {
 public:
+  /**
+   * @brief Construct a new MenuController.
+   * @param on_action Callback invoked when an item triggers an action.
+   */
   explicit MenuController(std::function<void(MenuAction)> on_action);
 
-  void on_key(UiKey key);       // recibe teclas, reinicia TTL
-  bool is_active() const;       // se muestra si hubo pulsación en timeout_ms
-  void draw(cv::Mat& canvas);   // dibuja overlay si activo
+  /**
+   * @brief Process a key event and reset the inactivity timer.
+   * @param key Navigation input.
+   */
+  void on_key(UiKey key);
 
-  void set_timeout_ms(int ms);  // por defecto 5000
-  void set_font_scale(double s);// tamaño de fuente OpenCV (0.4 por defecto)
+  /**
+   * @brief Whether the menu is currently visible/active.
+   * @return true if the menu is being displayed.
+   */
+  bool is_active() const;
+
+  /**
+   * @brief Draw the menu overlay onto the given canvas if active.
+   * @param canvas Target image.
+   */
+  void draw(cv::Mat& canvas);
+
+  /**
+   * @brief Configure inactivity timeout in milliseconds (default 5000).
+   * @param ms Timeout duration.
+   */
+  void set_timeout_ms(int ms);
+
+  /**
+   * @brief Set OpenCV font scale used for drawing (default 0.4).
+   * @param s Font scale factor.
+   */
+  void set_font_scale(double s);
 
 private:
   struct Item {
@@ -39,24 +76,83 @@ private:
     std::vector<Item> children;
   };
 
+  /**
+   * @brief Build the default menu hierarchy.
+   * @return Root item of the tree.
+   */
   static Item build_default_tree();
 
-  // navegación
+  // navigation
   std::vector<int> path_;
   int sel_{0};
   int offset_{0};
+
+  /**
+   * @brief Retrieve the currently selected menu.
+   * @return Pointer to const menu item.
+   */
   const Item* current_menu() const;
+
+  /**
+   * @brief Retrieve the currently selected menu.
+   * @return Pointer to mutable menu item.
+   */
   Item* current_menu();
 
+  /**
+   * @brief Enter the currently highlighted submenu or trigger its action.
+   */
   void enter();
+
+  /**
+   * @brief Navigate back to the parent menu.
+   */
   void back();
+
+  /**
+   * @brief Move selection up.
+   */
   void up();
+
+  /**
+   * @brief Move selection down.
+   */
   void down();
+
+  /**
+   * @brief Dispatch a menu action through the callback.
+   * @param a Action to send.
+   */
   void dispatch(MenuAction a);
 
-  // dibujo
+  // drawing helpers
+  /**
+   * @brief Draw the menu panel background.
+   * @param canvas Target image.
+   */
   void draw_panel(cv::Mat& canvas);
+
+  /**
+   * @brief Draw menu header text.
+   * @param img Target image.
+   * @param title Header title.
+   * @param x X coordinate.
+   * @param y Y coordinate.
+   * @param w Width of header area.
+   */
   void draw_header(cv::Mat& img, const std::string& title, int x, int y, int w);
+
+  /**
+   * @brief Draw individual menu items.
+   * @param img Target image.
+   * @param items Items to draw.
+   * @param x X coordinate.
+   * @param y Y coordinate.
+   * @param w Width of drawing area.
+   * @param line_h Height of a line.
+   * @param start First item index to show.
+   * @param max_items Maximum number of items to draw.
+   */
   void draw_items(cv::Mat& img, const std::vector<Item>& items, int x, int y,
                   int w, int line_h, int start, int max_items);
 


### PR DESCRIPTION
## Summary
- Replace line (`///`) comments with block Doxygen style and add parameter/return descriptions across headers
- Document AudioPlayer, Display, RoboEyes, Servo control, StateHandler, and menu controller classes using `@param` tags

## Testing
- `colcon build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5d51a6d083218453bfd34dffeacc