### PR TITLE
Add Wi-Fi status display

### DIFF
--- a/include/robofer/ui_menu.hpp
+++ b/include/robofer/ui_menu.hpp
@@ -74,6 +74,7 @@ private:
     bool is_submenu{false};
     MenuAction action{MenuAction::NONE};
     std::vector<Item> children;
+    cv::Scalar color{255,255,255};
   };
 
   /**


### PR DESCRIPTION
## Summary
- Add Wi-Fi submenu items for connection status and SSID
- Update menu drawing to colorize status and refresh dynamically

## Testing
- `colcon test` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package)*
- `g++ -std=c++17 -Iinclude -c src/ui_menu.cpp -o /tmp/ui_menu.o $(pkg-config --cflags opencv4 2>/tmp/opencv.log)` *(fails: opencv2/core.hpp: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68af2ae457e883218aead0736c3ceba6