### PR TITLE
Reduce menu font size and adjust layout dynamically

### DIFF
--- a/include/robofer/ui_menu.hpp
+++ b/include/robofer/ui_menu.hpp
@@ -63,7 +63,7 @@ public:
   void set_timeout_ms(int ms);
 
   /**
-   * @brief Set OpenCV font scale used for drawing (default 0.4).
+   * @brief Set OpenCV font scale used for drawing (default 0.15).
    * @param s Font scale factor.
    */
   void set_font_scale(double s);
@@ -141,7 +141,7 @@ private:
    * @param y Y coordinate.
    * @param w Width of header area.
    */
-  void draw_header(cv::Mat& img, const std::string& title, int x, int y, int w);
+  void draw_header(cv::Mat& img, const std::string& title, int x, int y, int w, int pad);
 
   /**
    * @brief Draw individual menu items.
@@ -155,12 +155,12 @@ private:
    * @param max_items Maximum number of items to draw.
    */
   void draw_items(cv::Mat& img, const std::vector<Item>& items, int x, int y,
-                  int w, int line_h, int start, int max_items);
+                   int w, int line_h, int start, int max_items, int pad);
 
   Item root_;
   std::function<void(MenuAction)> on_action_;
   int timeout_ms_{5000};
-  double font_scale_{0.45};
+  double font_scale_{0.15};
 
   using clock = std::chrono::steady_clock;
   clock::time_point last_key_time_;

--- a/src/eyes_unified_node.cpp
+++ b/src/eyes_unified_node.cpp
@@ -102,7 +102,7 @@ int main(int argc, char** argv){
 
   int DW = display->width();   if(DW <= 0) DW = eyes_w;
   int DH = display->height();  if(DH <= 0) DH = eyes_h;
-  menu.set_font_scale(std::clamp(DH / 100.0, 0.4, 1.0));
+  menu.set_font_scale(std::clamp(DH / 300.0, 0.1, 1.0));
   cv::Mat canvas(DH, DW, CV_8UC1, cv::Scalar(0));
 
   while(rclcpp::ok()){

--- a/src/ui_menu.cpp
+++ b/src/ui_menu.cpp
@@ -46,7 +46,7 @@ MenuController::MenuController(std::function<void(MenuAction)> on_action)
 }
 
 void MenuController::set_timeout_ms(int ms){ timeout_ms_ = std::max(0, ms); }
-void MenuController::set_font_scale(double s){ font_scale_ = std::clamp(s, 0.2, 2.0); }
+void MenuController::set_font_scale(double s){ font_scale_ = std::clamp(s, 0.1, 2.0); }
 
 bool MenuController::is_active() const {
   auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(clock::now() - last_key_time_).count();
@@ -144,21 +144,22 @@ void MenuController::draw_panel(cv::Mat& canvas){
     max_w = std::max(max_w, w);
   }
 
-  const int pad = std::max(4, W/64);
-  const int panel_w = std::min(W - 2*pad, std::max(max_w + 16, W*3/5));
+  const int outer_pad = std::max(4, W/64);
+  const int panel_w = std::min(W - 2*outer_pad, std::max(max_w + 16, W*3/5));
 
-  // Determine line height from font size
+  // Determine line height and padding from font size
   cv::Size sample_sz = cv::getTextSize("Ag", cv::FONT_HERSHEY_SIMPLEX,
                                       font_scale_, 1, &baseline);
-  const int line_h = std::max(12, sample_sz.height + baseline + 8);
+  const int text_pad = std::max(2, static_cast<int>(std::round(4 * font_scale_)));
+  const int line_h = std::max(8, sample_sz.height + baseline + text_pad*2);
 
   // Header height and total panel height
   cv::Size title_sz = cv::getTextSize(menu->label, cv::FONT_HERSHEY_SIMPLEX,
                                       font_scale_, 1, &baseline);
-  const int header_h = title_sz.height + 10;
-  const int max_visible = std::max(1, (H - 2*pad - header_h - 8) / line_h);
+  const int header_h = title_sz.height + text_pad*2;
+  const int max_visible = std::max(1, (H - 2*outer_pad - header_h - text_pad) / line_h);
   const int visible = std::min(max_visible, (int)menu->children.size());
-  const int panel_h = header_h + visible * line_h + 8;
+  const int panel_h = header_h + visible * line_h + text_pad;
 
   const int x = (W - panel_w) / 2;
   const int y = (H - panel_h) / 2;
@@ -168,27 +169,27 @@ void MenuController::draw_panel(cv::Mat& canvas){
 
   cv::rectangle(canvas, cv::Rect(x, y, panel_w, panel_h), cv::Scalar(200), 1, cv::LINE_8);
 
-  draw_header(canvas, menu->label, x, y, panel_w);
+  draw_header(canvas, menu->label, x, y, panel_w, text_pad);
 
   // Update offset to keep selection visible
   if(sel_ < offset_) offset_ = sel_;
   if(sel_ >= offset_ + visible) offset_ = sel_ - visible + 1;
   offset_ = std::clamp(offset_, 0, std::max(0, (int)menu->children.size() - visible));
 
-  draw_items(canvas, menu->children, x, y + header_h + 4, panel_w, line_h, offset_, visible);
+  draw_items(canvas, menu->children, x, y + header_h + text_pad, panel_w, line_h, offset_, visible, text_pad);
 }
 
-void MenuController::draw_header(cv::Mat& img, const std::string& title, int x, int y, int w){
+void MenuController::draw_header(cv::Mat& img, const std::string& title, int x, int y, int w, int pad){
   int baseline=0;
   cv::Size sz = cv::getTextSize(title, cv::FONT_HERSHEY_SIMPLEX, font_scale_, 1, &baseline);
-  int tx = x + 6;
-  int ty = y + sz.height + 6;
-  cv::rectangle(img, cv::Rect(x+1, y+1, w-2, sz.height + 10), cv::Scalar(200), cv::FILLED);
+  int tx = x + pad + 2;
+  int ty = y + sz.height + pad;
+  cv::rectangle(img, cv::Rect(x+1, y+1, w-2, sz.height + pad*2), cv::Scalar(200), cv::FILLED);
   cv::putText(img, title, cv::Point(tx, ty), cv::FONT_HERSHEY_SIMPLEX, font_scale_, cv::Scalar(0), 1, cv::LINE_8);
 }
 
 void MenuController::draw_items(cv::Mat& img, const std::vector<Item>& items, int x, int y,
-                                int w, int line_h, int start, int max_items){
+                                int w, int line_h, int start, int max_items, int pad){
   for(int row=0; row<max_items && start+row<(int)items.size(); ++row){
     int i = start + row;
     const auto& it = items[i];
@@ -201,8 +202,8 @@ void MenuController::draw_items(cv::Mat& img, const std::vector<Item>& items, in
     if(it.is_submenu) text += " >";
     int baseline=0;
     cv::Size sz = cv::getTextSize(text, cv::FONT_HERSHEY_SIMPLEX, font_scale_, 1, &baseline);
-    int tx = x + 8;
-    int ty = row_y + std::min(line_h-4, sz.height + 6);
+    int tx = x + pad + 4;
+    int ty = row_y + std::min(line_h - pad, sz.height + pad);
     cv::putText(img, text, cv::Point(tx, ty), cv::FONT_HERSHEY_SIMPLEX, font_scale_,
                 it.color, 1, cv::LINE_8);
   }


### PR DESCRIPTION
## Summary
- Shrink default menu font size and allow flexible scaling with new padding-aware layout
- Update display node to initialize menu font based on smaller scale

## Testing
- `cmake .. && make -j4` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68af2eb995188321958523166315f289