### PR TITLE
Improve menu text rendering and Wi-Fi status colors

### DIFF
--- a/src/eyes_unified_node.cpp
+++ b/src/eyes_unified_node.cpp
@@ -103,7 +103,7 @@ int main(int argc, char** argv){
   int DW = display->width();   if(DW <= 0) DW = eyes_w;
   int DH = display->height();  if(DH <= 0) DH = eyes_h;
   menu.set_font_scale(std::clamp(DH / 200.0, 0.1, 1.0));
-  cv::Mat canvas(DH, DW, CV_8UC1, cv::Scalar(0));
+  cv::Mat canvas(DH, DW, CV_8UC3, cv::Scalar(0,0,0));
 
   while(rclcpp::ok()){
     rclcpp::spin_some(node);
@@ -111,12 +111,13 @@ int main(int argc, char** argv){
     eyes.update();
     const cv::Mat& m = eyes.frame();
 
-    canvas.setTo(cv::Scalar(0));
+    canvas.setTo(cv::Scalar(0,0,0));
     int ox = std::max(0, (DW - m.cols)/2);
     int oy = std::max(0, (DH - m.rows)/2);
     cv::Rect roi(ox, oy, std::min(m.cols, DW-ox), std::min(m.rows, DH-oy));
     if(roi.width > 0 && roi.height > 0){
-      m(cv::Rect(0,0,roi.width,roi.height)).copyTo(canvas(roi));
+      cv::Mat src = m(cv::Rect(0,0,roi.width,roi.height));
+      cv::cvtColor(src, canvas(roi), cv::COLOR_GRAY2BGR);
     }
 
     {

--- a/src/ui_menu.cpp
+++ b/src/ui_menu.cpp
@@ -165,9 +165,10 @@ void MenuController::draw_panel(cv::Mat& canvas){
   const int y = (H - panel_h) / 2;
 
   cv::Mat roi = canvas(cv::Rect(x, y, panel_w, panel_h));
-  roi.setTo(cv::Scalar(40));
+  roi.setTo(cv::Scalar(40,40,40));
 
-  cv::rectangle(canvas, cv::Rect(x, y, panel_w, panel_h), cv::Scalar(200), 1, cv::LINE_8);
+  cv::rectangle(canvas, cv::Rect(x, y, panel_w, panel_h),
+                cv::Scalar(200,200,200), 1, cv::LINE_AA);
 
   draw_header(canvas, menu->label, x, y, panel_w, text_pad);
 
@@ -184,8 +185,10 @@ void MenuController::draw_header(cv::Mat& img, const std::string& title, int x, 
   cv::Size sz = cv::getTextSize(title, cv::FONT_HERSHEY_SIMPLEX, font_scale_, 1, &baseline);
   int tx = x + pad + 2;
   int ty = y + sz.height + pad;
-  cv::rectangle(img, cv::Rect(x+1, y+1, w-2, sz.height + pad*2), cv::Scalar(200), cv::FILLED);
-  cv::putText(img, title, cv::Point(tx, ty), cv::FONT_HERSHEY_SIMPLEX, font_scale_, cv::Scalar(0), 1, cv::LINE_8);
+  cv::rectangle(img, cv::Rect(x+1, y+1, w-2, sz.height + pad*2),
+                cv::Scalar(200,200,200), cv::FILLED);
+  cv::putText(img, title, cv::Point(tx, ty), cv::FONT_HERSHEY_SIMPLEX,
+              font_scale_, cv::Scalar(0,0,0), 1, cv::LINE_AA);
 }
 
 void MenuController::draw_items(cv::Mat& img, const std::vector<Item>& items, int x, int y,
@@ -196,7 +199,8 @@ void MenuController::draw_items(cv::Mat& img, const std::vector<Item>& items, in
     int row_y = y + row*line_h;
     bool sel = (i==sel_);
     if(sel){
-      cv::rectangle(img, cv::Rect(x+2, row_y, w-4, line_h-2), cv::Scalar(200), cv::FILLED);
+      cv::rectangle(img, cv::Rect(x+2, row_y, w-4, line_h-2),
+                    cv::Scalar(200,200,200), cv::FILLED);
     }
     std::string text = it.label;
     if(it.is_submenu) text += " >";
@@ -204,8 +208,8 @@ void MenuController::draw_items(cv::Mat& img, const std::vector<Item>& items, in
     cv::Size sz = cv::getTextSize(text, cv::FONT_HERSHEY_SIMPLEX, font_scale_, 1, &baseline);
     int tx = x + pad + 4;
     int ty = row_y + std::min(line_h - pad, sz.height + pad);
-    cv::putText(img, text, cv::Point(tx, ty), cv::FONT_HERSHEY_SIMPLEX, font_scale_,
-                it.color, 1, cv::LINE_8);
+    cv::putText(img, text, cv::Point(tx, ty), cv::FONT_HERSHEY_SIMPLEX,
+                font_scale_, it.color, 1, cv::LINE_AA);
   }
 }
 


### PR DESCRIPTION
## Summary
- Render menu text with anti-aliased fonts for clearer letters
- Show Wi-Fi connection status in green or red
- Support color frames in eyes display pipeline

## Testing
- `colcon build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af3592402c8321be2aab2a859abc02