### PR TITLE
Separate Wi-Fi and Bluetooth provisioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
@@ -19,6 +20,11 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/EyesCommand.msg"
   "msg/ServoGoal.msg"
   "msg/SoundRequest.msg"
+  "msg/WifiStatus.msg"
+  "msg/WifiNetwork.msg"
+  "srv/WifiGetStatus.srv"
+  "srv/WifiSetCredentials.srv"
+  "srv/WifiScan.srv"
   DEPENDENCIES std_msgs
 )
 
@@ -115,12 +121,14 @@ add_executable(eyes_unified_node
   src/screen/eyes_unified_node.cpp
   src/screen/ui_menu.cpp
 )
-ament_target_dependencies(eyes_unified_node rclcpp std_msgs)
+ament_target_dependencies(eyes_unified_node rclcpp std_msgs std_srvs)
 target_link_libraries(eyes_unified_node
   robo_eyes_lib
   robo_display
   ${OpenCV_LIBS}
 )
+rosidl_target_interfaces(eyes_unified_node
+  ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
 # --- Botones físicos ---
 add_executable(buttons_node
@@ -152,6 +160,21 @@ ament_target_dependencies(servo_monitor_node rclcpp)
 rosidl_target_interfaces(servo_monitor_node
   ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
+add_executable(wifi_manager_node
+  src/network/wifi_manager_node.cpp
+)
+ament_target_dependencies(wifi_manager_node rclcpp)
+rosidl_target_interfaces(wifi_manager_node
+  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+
+add_executable(bt_provision_node
+  src/network/bt_provision_node.cpp
+)
+ament_target_dependencies(bt_provision_node rclcpp)
+target_link_libraries(bt_provision_node bluetooth)
+rosidl_target_interfaces(bt_provision_node
+  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+
 # =========================================
 # 4) Instalación
 #    - Librerías a lib/
@@ -179,6 +202,8 @@ install(TARGETS
   keyboard_buttons_node
   state_handler_node
   servo_monitor_node
+  wifi_manager_node
+  bt_provision_node
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/include/robofer/screen/ui_menu.hpp
+++ b/include/robofer/screen/ui_menu.hpp
@@ -4,7 +4,6 @@
 #include <vector>
 #include <functional>
 #include <chrono>
-#include <future>
 
 namespace robo_ui {
 
@@ -22,6 +21,7 @@ enum class MenuAction {
   SET_SAD,
   SET_HAPPY,
   POWEROFF,
+  BT_CONNECT,
 };
 
 /**
@@ -68,6 +68,8 @@ public:
    * @param s Font scale factor.
    */
   void set_font_scale(double s);
+
+  void set_wifi_status(bool connected, const std::string& ssid);
 
 private:
   struct Item {
@@ -163,8 +165,6 @@ private:
   int timeout_ms_{5000};
   double font_scale_{0.15};
 
-  std::future<std::pair<bool, std::string>> wifi_future_;
-  bool wifi_requested_{false};
   
   using clock = std::chrono::steady_clock;
   clock::time_point last_key_time_;

--- a/msg/WifiNetwork.msg
+++ b/msg/WifiNetwork.msg
@@ -1,0 +1,3 @@
+string ssid
+int32 rssi
+string security

--- a/msg/WifiStatus.msg
+++ b/msg/WifiStatus.msg
@@ -1,0 +1,2 @@
+bool connected
+string ssid

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,10 @@
   <exec_depend>rclcpp</exec_depend>
   <build_depend>std_msgs</build_depend>
   <exec_depend>std_msgs</exec_depend>
+  <build_depend>std_srvs</build_depend>
+  <exec_depend>std_srvs</exec_depend>
+  <build_depend>libbluetooth-dev</build_depend>
+  <exec_depend>libbluetooth-dev</exec_depend>
 
   <build_depend>gpiod</build_depend>
   <exec_depend>gpiod</exec_depend>

--- a/src/network/bt_provision_node.cpp
+++ b/src/network/bt_provision_node.cpp
@@ -1,0 +1,89 @@
+#include <rclcpp/rclcpp.hpp>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/rfcomm.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <thread>
+#include <atomic>
+#include <string>
+#include <algorithm>
+#include <chrono>
+
+#include "robofer/srv/wifi_set_credentials.hpp"
+
+class BtProvisionNode : public rclcpp::Node {
+public:
+  BtProvisionNode() : Node("bt_provision_server") {
+    wifi_client_ = create_client<robofer::srv::WifiSetCredentials>("/wifi/set_credentials");
+    bt_thread_ = std::thread(&BtProvisionNode::server_loop_, this);
+  }
+  ~BtProvisionNode(){
+    running_ = false;
+    if(bt_thread_.joinable()) bt_thread_.join();
+  }
+private:
+  void server_loop_(){
+    int sock = socket(AF_BLUETOOTH, SOCK_STREAM, BTPROTO_RFCOMM);
+    if(sock < 0){
+      RCLCPP_ERROR(get_logger(), "Cannot create Bluetooth socket");
+      return;
+    }
+    sockaddr_rc loc = {0};
+    loc.rc_family = AF_BLUETOOTH;
+    bdaddr_t any = {0,0,0,0,0,0};
+    loc.rc_bdaddr = any;
+    loc.rc_channel = (uint8_t)3;
+    if(bind(sock, (struct sockaddr*)&loc, sizeof(loc)) < 0){
+      RCLCPP_ERROR(get_logger(), "Bind failed");
+      close(sock);
+      return;
+    }
+    listen(sock, 1);
+    while(running_){
+      sockaddr_rc rem = {0};
+      socklen_t opt = sizeof(rem);
+      int client = accept(sock, (struct sockaddr*)&rem, &opt);
+      if(client < 0) continue;
+      char buf[1024] = {0};
+      int bytes = read(client, buf, sizeof(buf)-1);
+      if(bytes > 0){
+        std::string msg(buf, bytes);
+        if(msg.rfind("HELLO",0) == 0){
+          std::string resp = "ROBOFER\n";
+          write(client, resp.c_str(), resp.size());
+        } else if(msg.rfind("SET:",0) == 0){
+          auto ssid_pos = msg.find("ssid=");
+          auto pass_pos = msg.find(";pass=");
+          if(ssid_pos != std::string::npos && pass_pos != std::string::npos){
+            std::string ssid = msg.substr(ssid_pos+5, pass_pos - (ssid_pos+5));
+            std::string pass = msg.substr(pass_pos+6);
+            pass.erase(std::remove(pass.begin(), pass.end(), '\n'), pass.end());
+            auto req = std::make_shared<robofer::srv::WifiSetCredentials::Request>();
+            req->ssid = ssid;
+            req->password = pass;
+            if(wifi_client_->wait_for_service(std::chrono::seconds(2))){
+              auto fut = wifi_client_->async_send_request(req);
+              fut.wait();
+              write(client, "OK\n", 3);
+            } else {
+              write(client, "ERROR:no_service\n", 18);
+            }
+          }
+        }
+      }
+      close(client);
+    }
+    close(sock);
+  }
+  rclcpp::Client<robofer::srv::WifiSetCredentials>::SharedPtr wifi_client_;
+  std::thread bt_thread_;
+  std::atomic<bool> running_{true};
+};
+
+int main(int argc, char** argv){
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<BtProvisionNode>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/network/wifi_manager_node.cpp
+++ b/src/network/wifi_manager_node.cpp
@@ -1,0 +1,123 @@
+#include <rclcpp/rclcpp.hpp>
+#include <cstdio>
+#include <array>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <algorithm>
+
+#include "robofer/msg/wifi_status.hpp"
+#include "robofer/msg/wifi_network.hpp"
+#include "robofer/srv/wifi_get_status.hpp"
+#include "robofer/srv/wifi_set_credentials.hpp"
+#include "robofer/srv/wifi_scan.hpp"
+
+using namespace std::chrono_literals;
+
+class WifiManager : public rclcpp::Node {
+public:
+  WifiManager() : Node("wifi_manager") {
+    status_pub_ = create_publisher<robofer::msg::WifiStatus>("/wifi/status", 10);
+    get_status_srv_ = create_service<robofer::srv::WifiGetStatus>(
+        "/wifi/get_status",
+        std::bind(&WifiManager::handle_get_status, this, std::placeholders::_1, std::placeholders::_2));
+    set_credentials_srv_ = create_service<robofer::srv::WifiSetCredentials>(
+        "/wifi/set_credentials",
+        std::bind(&WifiManager::handle_set_credentials, this, std::placeholders::_1, std::placeholders::_2));
+    scan_srv_ = create_service<robofer::srv::WifiScan>(
+        "/wifi/scan",
+        std::bind(&WifiManager::handle_scan, this, std::placeholders::_1, std::placeholders::_2));
+    timer_ = create_wall_timer(5s, std::bind(&WifiManager::update_status, this));
+    update_status();
+  }
+
+private:
+  robofer::msg::WifiStatus query_status(){
+    robofer::msg::WifiStatus st;
+    std::array<char,128> buf{};
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(
+        popen("nmcli -t -f ACTIVE,SSID dev wifi | grep '^yes' | cut -d: -f2", "r"), pclose);
+    if(pipe && fgets(buf.data(), buf.size(), pipe.get())){
+      std::string ssid = buf.data();
+      ssid.erase(std::remove(ssid.begin(), ssid.end(), '\n'), ssid.end());
+      st.connected = !ssid.empty();
+      st.ssid = ssid;
+    } else {
+      st.connected = false;
+      st.ssid = "";
+    }
+    return st;
+  }
+
+  void update_status(){
+    auto st = query_status();
+    {
+      std::lock_guard<std::mutex> lk(mtx_);
+      last_status_ = st;
+    }
+    status_pub_->publish(st);
+  }
+
+  void handle_get_status(const std::shared_ptr<robofer::srv::WifiGetStatus::Request> req,
+                         std::shared_ptr<robofer::srv::WifiGetStatus::Response> res){
+    (void)req;
+    std::lock_guard<std::mutex> lk(mtx_);
+    res->connected = last_status_.connected;
+    res->ssid = last_status_.ssid;
+  }
+
+  void handle_set_credentials(const std::shared_ptr<robofer::srv::WifiSetCredentials::Request> req,
+                              std::shared_ptr<robofer::srv::WifiSetCredentials::Response> res){
+    {
+      std::lock_guard<std::mutex> lk(mtx_);
+      ssid_ = req->ssid;
+      pass_ = req->password;
+    }
+    std::string cmd = "nmcli dev wifi connect '" + req->ssid + "' password '" + req->password + "'";
+    int ret = std::system(cmd.c_str());
+    res->success = (ret == 0);
+    res->message = ret==0 ? "OK" : "nmcli failed";
+    update_status();
+  }
+
+  void handle_scan(const std::shared_ptr<robofer::srv::WifiScan::Request> req,
+                   std::shared_ptr<robofer::srv::WifiScan::Response> res){
+    (void)req;
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(
+        popen("nmcli -t -f SSID,SIGNAL,SECURITY dev wifi", "r"), pclose);
+    if(!pipe) return;
+    char line[256];
+    while(fgets(line, sizeof(line), pipe.get())){
+      std::string l(line);
+      l.erase(std::remove(l.begin(), l.end(), '\n'), l.end());
+      std::stringstream ss(l);
+      std::string ssid, signal_str, sec;
+      std::getline(ss, ssid, ':');
+      std::getline(ss, signal_str, ':');
+      std::getline(ss, sec, ':');
+      robofer::msg::WifiNetwork net;
+      net.ssid = ssid;
+      net.rssi = signal_str.empty() ? 0 : std::stoi(signal_str);
+      net.security = sec;
+      res->networks.push_back(net);
+    }
+  }
+
+  rclcpp::Publisher<robofer::msg::WifiStatus>::SharedPtr status_pub_;
+  rclcpp::Service<robofer::srv::WifiGetStatus>::SharedPtr get_status_srv_;
+  rclcpp::Service<robofer::srv::WifiSetCredentials>::SharedPtr set_credentials_srv_;
+  rclcpp::Service<robofer::srv::WifiScan>::SharedPtr scan_srv_;
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  std::string ssid_;
+  std::string pass_;
+  robofer::msg::WifiStatus last_status_;
+  std::mutex mtx_;
+};
+
+int main(int argc, char** argv){
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<WifiManager>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/srv/WifiGetStatus.srv
+++ b/srv/WifiGetStatus.srv
@@ -1,0 +1,4 @@
+# Request
+---
+bool connected
+string ssid

--- a/srv/WifiScan.srv
+++ b/srv/WifiScan.srv
@@ -1,0 +1,3 @@
+# Request
+---
+robofer/WifiNetwork[] networks

--- a/srv/WifiSetCredentials.srv
+++ b/srv/WifiSetCredentials.srv
@@ -1,0 +1,5 @@
+string ssid
+string password
+---
+bool success
+string message


### PR DESCRIPTION
## Summary
- Expose Wi-Fi status via dedicated `wifi_manager` node with scan and credential services
- Add Bluetooth provisioning server that forwards credentials to Wi-Fi manager
- Update menu and unified eyes node to use ROS Wi-Fi status and trigger BT connect

## Testing
- `\colcon build --packages-select robofer`

------
https://chatgpt.com/codex/tasks/task_e_68b02dd208ac8321b837d6c5b395a7fa