### PR TITLE
Prevent double close of server socket

### DIFF
--- a/src/network/bt_provision_node.cpp
+++ b/src/network/bt_provision_node.cpp
@@ -22,6 +22,7 @@ public:
     if(server_sock_ >= 0){
       shutdown(server_sock_, SHUT_RDWR);
       close(server_sock_);
+      server_sock_ = -1;
     }
     if(bt_thread_.joinable()) bt_thread_.join();
   }


### PR DESCRIPTION
## Summary
- reset `server_sock_` to `-1` after closing it in `BtProvisionNode` destructor to avoid double closing

## Testing
- `colcon test` *(fails: argument verb_name invalid choice '--cmake-args')*


------
https://chatgpt.com/codex/tasks/task_e_68b03d8be1808321bead62bf6f841f8c