### PR TITLE
feat: support Bluetooth password provisioning

### DIFF
--- a/src/network/BtProvisionNode.cpp
+++ b/src/network/BtProvisionNode.cpp
@@ -26,71 +26,104 @@ public:
     if(bt_thread_.joinable()) bt_thread_.join();
   }
 private:
-  void serverLoop(){
+  bool sendCredentials(const std::string &ssid, const std::string &pass) {
+    auto req = std::make_shared<robofer::srv::WifiSetCredentials::Request>();
+    req->ssid = ssid;
+    req->password = pass;
+    if (wifi_client_->wait_for_service(std::chrono::seconds(2))) {
+      auto fut = wifi_client_->async_send_request(req);
+      fut.wait();
+      auto res = fut.get();
+      return res->success;
+    }
+    return false;
+  }
+
+  void serverLoop() {
     int sock = socket(AF_BLUETOOTH, SOCK_STREAM, BTPROTO_RFCOMM);
-    if(sock < 0){
+    if (sock < 0) {
       RCLCPP_ERROR(get_logger(), "Cannot create Bluetooth socket");
       return;
     }
     server_sock_ = sock;
     sockaddr_rc loc = {0};
     loc.rc_family = AF_BLUETOOTH;
-    bdaddr_t any = {0,0,0,0,0,0};
+    bdaddr_t any = {0, 0, 0, 0, 0, 0};
     loc.rc_bdaddr = any;
     loc.rc_channel = (uint8_t)3;
-    if(bind(server_sock_, (struct sockaddr*)&loc, sizeof(loc)) < 0){
+    if (bind(server_sock_, (struct sockaddr *)&loc, sizeof(loc)) < 0) {
       RCLCPP_ERROR(get_logger(), "Bind failed");
       close(server_sock_);
       server_sock_ = -1;
       return;
     }
     listen(server_sock_, 1);
-    while(running_){
+    while (running_) {
       sockaddr_rc rem = {0};
       socklen_t opt = sizeof(rem);
-      int client = accept(server_sock_, (struct sockaddr*)&rem, &opt);
-      if(client < 0){
-        if(!running_) break;
+      int client = accept(server_sock_, (struct sockaddr *)&rem, &opt);
+      if (client < 0) {
+        if (!running_) break;
         continue;
       }
       char buf[1024] = {0};
-      int bytes = read(client, buf, sizeof(buf)-1);
-      if(bytes > 0){
+      int bytes = read(client, buf, sizeof(buf) - 1);
+      if (bytes > 0) {
         std::string msg(buf, bytes);
-        if(msg.rfind("HELLO",0) == 0){
+        if (msg.rfind("HELLO", 0) == 0) {
           std::string resp = "ROBOFER\n";
           write(client, resp.c_str(), resp.size());
-        } else if(msg.rfind("SET:",0) == 0){
+        } else if (msg.rfind("SET:", 0) == 0) {
           auto ssid_pos = msg.find("ssid=");
           auto pass_pos = msg.find(";pass=");
-          if(ssid_pos != std::string::npos && pass_pos != std::string::npos){
-            std::string ssid = msg.substr(ssid_pos+5, pass_pos - (ssid_pos+5));
-            std::string pass = msg.substr(pass_pos+6);
+          if (ssid_pos != std::string::npos && pass_pos != std::string::npos) {
+            std::string ssid =
+                msg.substr(ssid_pos + 5, pass_pos - (ssid_pos + 5));
+            std::string pass = msg.substr(pass_pos + 6);
             pass.erase(std::remove(pass.begin(), pass.end(), '\n'), pass.end());
-            auto req = std::make_shared<robofer::srv::WifiSetCredentials::Request>();
-            req->ssid = ssid;
-            req->password = pass;
-            if(wifi_client_->wait_for_service(std::chrono::seconds(2))){
-              auto fut = wifi_client_->async_send_request(req);
-              fut.wait();
+            bool ok = sendCredentials(ssid, pass);
+            if (ok) {
               write(client, "OK\n", 3);
             } else {
-              write(client, "ERROR:no_service\n", 18);
+              write(client, "ERROR:connect\n", 14);
             }
+          }
+        } else if (msg.rfind("SSID:", 0) == 0) {
+          pending_ssid_ = msg.substr(5);
+          pending_ssid_.erase(
+              std::remove(pending_ssid_.begin(), pending_ssid_.end(), '\n'),
+              pending_ssid_.end());
+          write(client, "OK\n", 3);
+        } else if (msg.rfind("PASS:", 0) == 0) {
+          pending_pass_ = msg.substr(5);
+          pending_pass_.erase(
+              std::remove(pending_pass_.begin(), pending_pass_.end(), '\n'),
+              pending_pass_.end());
+          if (!pending_ssid_.empty()) {
+            bool ok = sendCredentials(pending_ssid_, pending_pass_);
+            write(client, ok ? "OK\n" : "ERROR:connect\n",
+                  ok ? 3 : 14);
+            pending_ssid_.clear();
+            pending_pass_.clear();
+          } else {
+            write(client, "ERROR:no_ssid\n", 15);
           }
         }
       }
       close(client);
     }
-    if(server_sock_ >= 0){
+    if (server_sock_ >= 0) {
       close(server_sock_);
       server_sock_ = -1;
     }
   }
+
   rclcpp::Client<robofer::srv::WifiSetCredentials>::SharedPtr wifi_client_;
   std::thread bt_thread_;
   std::atomic<bool> running_{true};
   int server_sock_{-1};
+  std::string pending_ssid_;
+  std::string pending_pass_;
 };
 
 int main(int argc, char** argv){


### PR DESCRIPTION
## Summary
- allow Bluetooth provisioning node to relay password-only or combined Wi-Fi credentials
- forward credentials to Wi-Fi manager via ROS service and report connection result

## Testing
- `set -euo pipefail` *(fails: `/opt/ros/jazzy/setup.bash: line 8: AMENT_TRACE_SETUP_FILES: unbound variable`)*
- `which python3`
- `python3 -V`
- `python3 -c "import em"`
- `\colcon build 2>&1 | head -n 200`
- `\colcon test 2>&1 | head -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68b0acc39fbc8321910abd4d35d8b2c0