### PR TITLE
Add Bluetooth provisioning server and menu hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/WifiGetStatus.srv"
   "srv/WifiSetCredentials.srv"
   "srv/WifiScan.srv"
+  "srv/SetBoolWithCode.srv"
   DEPENDENCIES std_msgs
 )
 

--- a/include/robofer/screen/UiMenu.hpp
+++ b/include/robofer/screen/UiMenu.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <functional>
 #include <chrono>
+#include <cstdint>
 
 namespace robo_ui {
 
@@ -22,6 +23,9 @@ enum class MenuAction {
   SET_HAPPY,
   POWEROFF,
   BT_CONNECT,
+  BT_ACCEPT,
+  BT_REJECT,
+  BT_STOP,
 };
 
 /**
@@ -70,6 +74,7 @@ public:
   void setFontScale(double s);
 
   void setWifiStatus(bool connected, const std::string& ssid);
+  void setBtState(const std::string& state, uint32_t code);
 
 private:
   struct Item {

--- a/src/network/BtProvisionNode.cpp
+++ b/src/network/BtProvisionNode.cpp
@@ -1,4 +1,6 @@
 #include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <std_srvs/srv/trigger.hpp>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/rfcomm.h>
 #include <sys/socket.h>
@@ -6,32 +8,53 @@
 #include <thread>
 #include <atomic>
 #include <string>
+#include <sstream>
 #include <algorithm>
-#include <chrono>
+#include <random>
 
 #include "robofer/srv/wifi_set_credentials.hpp"
+#include "robofer/srv/wifi_scan.hpp"
+#include "robofer/srv/wifi_get_status.hpp"
+#include "robofer/srv/set_bool_with_code.hpp"
+
+using namespace std::chrono_literals;
 
 class BtProvisionNode : public rclcpp::Node {
 public:
   BtProvisionNode() : Node("bt_provision_server") {
-    wifi_client_ = create_client<robofer::srv::WifiSetCredentials>("/wifi/set_credentials");
-    bt_thread_ = std::thread(&BtProvisionNode::serverLoop, this);
+    state_pub_ = create_publisher<std_msgs::msg::String>("/wifi_prov/state", 10);
+    start_srv_ = create_service<std_srvs::srv::Trigger>(
+        "/wifi_prov/start",
+        std::bind(&BtProvisionNode::handleStart, this, std::placeholders::_1, std::placeholders::_2));
+    stop_srv_ = create_service<std_srvs::srv::Trigger>(
+        "/wifi_prov/stop",
+        std::bind(&BtProvisionNode::handleStop, this, std::placeholders::_1, std::placeholders::_2));
+    confirm_srv_ = create_service<robofer::srv::SetBoolWithCode>(
+        "/wifi_prov/confirm",
+        std::bind(&BtProvisionNode::handleConfirm, this, std::placeholders::_1, std::placeholders::_2));
+
+    wifi_set_client_ = create_client<robofer::srv::WifiSetCredentials>("/wifi/set_credentials");
+    wifi_scan_client_ = create_client<robofer::srv::WifiScan>("/wifi/scan");
+    wifi_status_client_ = create_client<robofer::srv::WifiGetStatus>("/wifi/get_status");
+
+    publishState("IDLE");
   }
-  ~BtProvisionNode(){
-    running_ = false;
-    if(server_sock_ >= 0){
-      shutdown(server_sock_, SHUT_RDWR);
-      close(server_sock_);
-    }
-    if(bt_thread_.joinable()) bt_thread_.join();
-  }
+
+  ~BtProvisionNode(){ stopServer(); }
+
 private:
+  enum class State {IDLE, WAITING_PAIRING, SPP_READY, CONNECTED};
+
+  void publishState(const std::string& st){
+    std_msgs::msg::String msg; msg.data = st; state_pub_->publish(msg);
+  }
+
   bool sendCredentials(const std::string &ssid, const std::string &pass) {
     auto req = std::make_shared<robofer::srv::WifiSetCredentials::Request>();
     req->ssid = ssid;
     req->password = pass;
-    if (wifi_client_->wait_for_service(std::chrono::seconds(2))) {
-      auto fut = wifi_client_->async_send_request(req);
+    if (wifi_set_client_->wait_for_service(2s)) {
+      auto fut = wifi_set_client_->async_send_request(req);
       fut.wait();
       auto res = fut.get();
       return res->success;
@@ -39,97 +62,164 @@ private:
     return false;
   }
 
-  void serverLoop() {
-    int sock = socket(AF_BLUETOOTH, SOCK_STREAM, BTPROTO_RFCOMM);
-    if (sock < 0) {
-      RCLCPP_ERROR(get_logger(), "Cannot create Bluetooth socket");
-      return;
+  std::string currentSsid(){
+    auto req = std::make_shared<robofer::srv::WifiGetStatus::Request>();
+    if(wifi_status_client_->wait_for_service(2s)){
+      auto fut = wifi_status_client_->async_send_request(req);
+      fut.wait();
+      auto res = fut.get();
+      if(res->connected) return res->ssid;
     }
-    server_sock_ = sock;
-    sockaddr_rc loc = {0};
-    loc.rc_family = AF_BLUETOOTH;
-    bdaddr_t any = {0, 0, 0, 0, 0, 0};
-    loc.rc_bdaddr = any;
-    loc.rc_channel = (uint8_t)3;
-    if (bind(server_sock_, (struct sockaddr *)&loc, sizeof(loc)) < 0) {
-      RCLCPP_ERROR(get_logger(), "Bind failed");
-      close(server_sock_);
-      server_sock_ = -1;
-      return;
+    return "ROBOFER";
+  }
+
+  void sendScanResults(int client){
+    auto req = std::make_shared<robofer::srv::WifiScan::Request>();
+    if(!wifi_scan_client_->wait_for_service(2s)) return;
+    auto fut = wifi_scan_client_->async_send_request(req);
+    fut.wait();
+    auto res = fut.get();
+    for(const auto &net : res->networks){
+      std::ostringstream oss;
+      oss << "NET:ssid=" << net.ssid << ";rssi=" << net.rssi << ";sec=" << net.security << "\n";
+      auto s = oss.str();
+      ::write(client, s.c_str(), s.size());
     }
-    listen(server_sock_, 1);
-    while (running_) {
-      sockaddr_rc rem = {0};
-      socklen_t opt = sizeof(rem);
-      int client = accept(server_sock_, (struct sockaddr *)&rem, &opt);
-      if (client < 0) {
-        if (!running_) break;
-        continue;
-      }
-      char buf[1024] = {0};
-      int bytes = read(client, buf, sizeof(buf) - 1);
-      if (bytes > 0) {
-        std::string msg(buf, bytes);
-        if (msg.rfind("HELLO", 0) == 0) {
-          std::string resp = "ROBOFER\n";
-          write(client, resp.c_str(), resp.size());
-        } else if (msg.rfind("SET:", 0) == 0) {
-          auto ssid_pos = msg.find("ssid=");
-          auto pass_pos = msg.find(";pass=");
-          if (ssid_pos != std::string::npos && pass_pos != std::string::npos) {
-            std::string ssid =
-                msg.substr(ssid_pos + 5, pass_pos - (ssid_pos + 5));
-            std::string pass = msg.substr(pass_pos + 6);
-            pass.erase(std::remove(pass.begin(), pass.end(), '\n'), pass.end());
-            bool ok = sendCredentials(ssid, pass);
-            if (ok) {
-              write(client, "OK\n", 3);
-            } else {
-              write(client, "ERROR:connect\n", 14);
-            }
-          }
-        } else if (msg.rfind("SSID:", 0) == 0) {
-          pending_ssid_ = msg.substr(5);
-          pending_ssid_.erase(
-              std::remove(pending_ssid_.begin(), pending_ssid_.end(), '\n'),
-              pending_ssid_.end());
-          write(client, "OK\n", 3);
-        } else if (msg.rfind("PASS:", 0) == 0) {
-          pending_pass_ = msg.substr(5);
-          pending_pass_.erase(
-              std::remove(pending_pass_.begin(), pending_pass_.end(), '\n'),
-              pending_pass_.end());
-          if (!pending_ssid_.empty()) {
-            bool ok = sendCredentials(pending_ssid_, pending_pass_);
-            write(client, ok ? "OK\n" : "ERROR:connect\n",
-                  ok ? 3 : 14);
-            pending_ssid_.clear();
-            pending_pass_.clear();
-          } else {
-            write(client, "ERROR:no_ssid\n", 15);
-          }
-        }
-      }
-      close(client);
+    ::write(client, "END\n", 4);
+  }
+
+  void handleStart(const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+                   std::shared_ptr<std_srvs::srv::Trigger::Response> res){
+    (void)req;
+    if(state_ != State::IDLE){
+      res->success = false; res->message = "busy"; return;
     }
-    if (server_sock_ >= 0) {
-      close(server_sock_);
-      server_sock_ = -1;
+    std::random_device rd; std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint32_t> dist(100000, 999999);
+    passkey_ = dist(gen);
+    state_ = State::WAITING_PAIRING;
+    publishState("CONFIRM_CODE:" + std::to_string(passkey_));
+    res->success = true; res->message = "started";
+  }
+
+  void handleStop(const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+                  std::shared_ptr<std_srvs::srv::Trigger::Response> res){
+    (void)req;
+    stopServer();
+    state_ = State::IDLE;
+    publishState("IDLE");
+    res->success = true; res->message = "stopped";
+  }
+
+  void handleConfirm(const std::shared_ptr<robofer::srv::SetBoolWithCode::Request> req,
+                     std::shared_ptr<robofer::srv::SetBoolWithCode::Response> res){
+    if(state_ != State::WAITING_PAIRING || req->code != passkey_){
+      res->success = false; res->message = "invalid"; return;
+    }
+    if(req->accept){
+      startServer();
+      res->success = true; res->message = "accepted";
+    } else {
+      state_ = State::IDLE;
+      publishState("IDLE");
+      res->success = true; res->message = "rejected";
     }
   }
 
-  rclcpp::Client<robofer::srv::WifiSetCredentials>::SharedPtr wifi_client_;
-  std::thread bt_thread_;
-  std::atomic<bool> running_{true};
+  void startServer(){
+    if(running_) return;
+    running_ = true;
+    server_thread_ = std::thread(&BtProvisionNode::serverLoop, this);
+    state_ = State::SPP_READY;
+    publishState("SPP_READY");
+  }
+
+  void stopServer(){
+    running_ = false;
+    if(server_sock_ >= 0){
+      ::shutdown(server_sock_, SHUT_RDWR);
+      ::close(server_sock_);
+      server_sock_ = -1;
+    }
+    if(server_thread_.joinable()) server_thread_.join();
+  }
+
+  void serverLoop(){
+    int sock = ::socket(AF_BLUETOOTH, SOCK_STREAM, BTPROTO_RFCOMM);
+    if(sock < 0){
+      RCLCPP_ERROR(get_logger(), "Cannot create Bluetooth socket");
+      running_ = false; return;
+    }
+    server_sock_ = sock;
+    sockaddr_rc loc{}; loc.rc_family = AF_BLUETOOTH; loc.rc_channel = (uint8_t)3; bdaddr_t any{}; loc.rc_bdaddr = any;
+    if(::bind(server_sock_, (struct sockaddr*)&loc, sizeof(loc)) < 0){
+      RCLCPP_ERROR(get_logger(), "Bind failed");
+      ::close(server_sock_); server_sock_ = -1; running_ = false; return;
+    }
+    ::listen(server_sock_, 1);
+    while(running_){
+      sockaddr_rc rem{}; socklen_t opt = sizeof(rem);
+      int client = ::accept(server_sock_, (struct sockaddr*)&rem, &opt);
+      if(client < 0){ if(!running_) break; continue; }
+      state_ = State::CONNECTED;
+      publishState("CONNECTED");
+      handleClient(client);
+      ::close(client);
+      state_ = State::SPP_READY;
+      publishState("SPP_READY");
+    }
+    ::close(server_sock_); server_sock_ = -1;
+    running_ = false;
+  }
+
+  void handleClient(int client){
+    char buf[1024];
+    while(true){
+      int bytes = ::read(client, buf, sizeof(buf)-1);
+      if(bytes <= 0) break;
+      std::string msg(buf, bytes);
+      if(msg.rfind("HELLO",0) == 0){
+        std::string resp = std::string("SSID:") + currentSsid() + "\n";
+        ::write(client, resp.c_str(), resp.size());
+      } else if(msg.rfind("LIST",0) == 0){
+        sendScanResults(client);
+      } else if(msg.rfind("SET:",0) == 0){
+        auto ssid_pos = msg.find("ssid=");
+        auto pass_pos = msg.find(";pass=");
+        if(ssid_pos != std::string::npos && pass_pos != std::string::npos){
+          std::string ssid = msg.substr(ssid_pos+5, pass_pos - (ssid_pos+5));
+          std::string pass = msg.substr(pass_pos+6);
+          pass.erase(std::remove(pass.begin(), pass.end(), '\n'), pass.end());
+          bool ok = sendCredentials(ssid, pass);
+          if(ok){
+            ::write(client, "OK\n", 3);
+          } else {
+            ::write(client, "ERROR:connect\n", 14);
+          }
+        }
+      }
+    }
+  }
+
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr state_pub_;
+  rclcpp::Client<robofer::srv::WifiSetCredentials>::SharedPtr wifi_set_client_;
+  rclcpp::Client<robofer::srv::WifiScan>::SharedPtr wifi_scan_client_;
+  rclcpp::Client<robofer::srv::WifiGetStatus>::SharedPtr wifi_status_client_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr start_srv_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr stop_srv_;
+  rclcpp::Service<robofer::srv::SetBoolWithCode>::SharedPtr confirm_srv_;
+
+  std::atomic<State> state_{State::IDLE};
+  uint32_t passkey_{0};
+  std::atomic<bool> running_{false};
   int server_sock_{-1};
-  std::string pending_ssid_;
-  std::string pending_pass_;
+  std::thread server_thread_;
 };
 
 int main(int argc, char** argv){
   rclcpp::init(argc, argv);
-  auto node = std::make_shared<BtProvisionNode>();
-  rclcpp::spin(node);
+  rclcpp::spin(std::make_shared<BtProvisionNode>());
   rclcpp::shutdown();
   return 0;
 }
+

--- a/src/screen/UiMenu.cpp
+++ b/src/screen/UiMenu.cpp
@@ -16,7 +16,10 @@ MenuController::Item MenuController::buildDefaultTree(){
   Item wifi; wifi.label = "Wi-Fi"; wifi.is_submenu = true;
   wifi.children.push_back({"Status: --", false, MenuAction::NONE, {}});
   wifi.children.push_back({"SSID: --",   false, MenuAction::NONE, {}});
-  wifi.children.push_back({"BT connect", false, MenuAction::BT_CONNECT, {}});
+  wifi.children.push_back({"Start provisioning", false, MenuAction::BT_CONNECT, {}});
+  wifi.children.push_back({"Accept", false, MenuAction::BT_ACCEPT, {}});
+  wifi.children.push_back({"Reject", false, MenuAction::BT_REJECT, {}});
+  wifi.children.push_back({"Stop provisioning", false, MenuAction::BT_STOP, {}});
 
   Item apagar; apagar.label = "Apagar"; apagar.is_submenu = false; apagar.action = MenuAction::POWEROFF;
 
@@ -40,6 +43,42 @@ void MenuController::setWifiStatus(bool connected, const std::string& ssid){
       wifi.children[0].label = std::string("Status: ") + (connected ? "Connected" : "Disconnected");
       wifi.children[0].color = connected ? cv::Scalar(0,255,0) : cv::Scalar(0,0,255);
       wifi.children[1].label = std::string("SSID: ") + (connected ? ssid : "-");
+    }
+  }
+}
+
+void MenuController::setBtState(const std::string& state, uint32_t code){
+  if(root_.children.size() > 1){
+    Item& wifi = root_.children[1];
+    if(wifi.label == "Wi-Fi" && wifi.children.size() >= 6){
+      // item2: start/state label
+      if(state == "IDLE"){
+        wifi.children[2].label = "Start provisioning";
+        wifi.children[2].action = MenuAction::BT_CONNECT;
+      } else {
+        wifi.children[2].label = std::string("State: ") + state;
+        wifi.children[2].action = MenuAction::NONE;
+      }
+      // items for confirm
+      if(state.rfind("CONFIRM_CODE",0) == 0){
+        wifi.children[3].label = std::string("Accept ") + std::to_string(code);
+        wifi.children[3].action = MenuAction::BT_ACCEPT;
+        wifi.children[4].label = "Reject";
+        wifi.children[4].action = MenuAction::BT_REJECT;
+      } else {
+        wifi.children[3].label = "";
+        wifi.children[3].action = MenuAction::NONE;
+        wifi.children[4].label = "";
+        wifi.children[4].action = MenuAction::NONE;
+      }
+      // item5: stop provisioning if not idle
+      if(state == "IDLE"){
+        wifi.children[5].label = "";
+        wifi.children[5].action = MenuAction::NONE;
+      } else {
+        wifi.children[5].label = "Stop provisioning";
+        wifi.children[5].action = MenuAction::BT_STOP;
+      }
     }
   }
 }

--- a/srv/SetBoolWithCode.srv
+++ b/srv/SetBoolWithCode.srv
@@ -1,0 +1,5 @@
+bool accept
+uint32 code
+---
+bool success
+string message


### PR DESCRIPTION
## Summary
- add SetBoolWithCode service and expose in CMake
- implement Bluetooth provisioning node with start/stop/confirm and Wi-Fi operations
- extend UI menu and eyes node to control and display provisioning state

## Testing
- `which python3`
- `python3 -V`
- `python3 -c "import em"`
- `\colcon build 2>&1 | head -n 200`
- `\colcon test 2>&1 | head -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68b0b61dcea0832193a24fc694726c29