### PR TITLE
feat: add bluetooth menu and manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,10 +168,17 @@ ament_target_dependencies(wifi_manager_node rclcpp)
 rosidl_target_interfaces(wifi_manager_node
   ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
+add_executable(bluetooth_manager_node
+  src/network/BluetoothManagerNode.cpp
+)
+ament_target_dependencies(bluetooth_manager_node rclcpp std_msgs std_srvs)
+rosidl_target_interfaces(bluetooth_manager_node
+  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+
 add_executable(bt_provision_node
   src/network/BtProvisionNode.cpp
 )
-ament_target_dependencies(bt_provision_node rclcpp)
+ament_target_dependencies(bt_provision_node rclcpp std_srvs)
 target_link_libraries(bt_provision_node bluetooth)
 rosidl_target_interfaces(bt_provision_node
   ${PROJECT_NAME} "rosidl_typesupport_cpp")
@@ -204,6 +211,7 @@ install(TARGETS
   state_handler_node
   servo_monitor_node
   wifi_manager_node
+  bluetooth_manager_node
   bt_provision_node
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/include/robofer/screen/UiMenu.hpp
+++ b/include/robofer/screen/UiMenu.hpp
@@ -26,6 +26,10 @@ enum class MenuAction {
   BT_ACCEPT,
   BT_REJECT,
   BT_STOP,
+  BT_ON,
+  BT_OFF,
+  BT_PAIR_ACCEPT,
+  BT_PAIR_REJECT,
 };
 
 /**
@@ -75,6 +79,7 @@ public:
 
   void setWifiStatus(bool connected, const std::string& ssid);
   void setBtState(const std::string& state, uint32_t code);
+  void setBluetoothState(bool enabled, const std::string& device);
 
 private:
   struct Item {

--- a/launch/eyes_system.launch.py
+++ b/launch/eyes_system.launch.py
@@ -126,6 +126,13 @@ def generate_launch_description():
         output='screen',
     )
 
+    bt_node = Node(
+        package='robofer',
+        executable='bluetooth_manager_node',
+        name='bluetooth_manager_node',
+        output='screen',
+    )
+
     # ========= LAUNCH DESCRIPTION =========
     ld = LaunchDescription()
 
@@ -169,5 +176,6 @@ def generate_launch_description():
     ld.add_action(keyboard_node)
     ld.add_action(buttons_node)
     ld.add_action(wifi_node)
+    ld.add_action(bt_node)
 
     return ld

--- a/launch/robofer.launch.py
+++ b/launch/robofer.launch.py
@@ -9,5 +9,6 @@ def generate_launch_description():
         Node(package="robofer", executable="state_handler_node", name="state_handler"),
         Node(package="robofer", executable="buttons_node", name="buttons"),
         Node(package="robofer", executable="wifi_manager_node", name="wifi_manager"),
+        Node(package="robofer", executable="bluetooth_manager_node", name="bluetooth_manager"),
     ])
 

--- a/launch/robofer_sim.launch.py
+++ b/launch/robofer_sim.launch.py
@@ -24,4 +24,10 @@ def generate_launch_description():
             name='wifi_manager',
             output='screen',
         ),
+        Node(
+            package='robofer',
+            executable='bluetooth_manager_node',
+            name='bluetooth_manager',
+            output='screen',
+        ),
     ])

--- a/src/network/BluetoothManagerNode.cpp
+++ b/src/network/BluetoothManagerNode.cpp
@@ -1,0 +1,88 @@
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <std_srvs/srv/set_bool.hpp>
+#include <string>
+
+using namespace std::placeholders;
+
+class BluetoothManager : public rclcpp::Node {
+public:
+  BluetoothManager() : Node("bluetooth_manager") {
+    state_pub_ = create_publisher<std_msgs::msg::String>("/bluetooth/state", 10);
+    power_srv_ = create_service<std_srvs::srv::SetBool>(
+        "/bluetooth/power", std::bind(&BluetoothManager::handlePower, this, _1, _2));
+    pair_srv_ = create_service<std_srvs::srv::SetBool>(
+        "/bluetooth/pair_response", std::bind(&BluetoothManager::handlePair, this, _1, _2));
+    pair_sub_ = create_subscription<std_msgs::msg::String>(
+        "/bluetooth/pair_request", 10,
+        std::bind(&BluetoothManager::onPairRequest, this, _1));
+    publishState();
+  }
+
+private:
+  void publishState(){
+    std_msgs::msg::String msg;
+    if(!enabled_){
+      msg.data = "OFF";
+    } else if(pending_device_.empty()){
+      msg.data = "ON";
+    } else {
+      msg.data = std::string("REQUEST:") + pending_device_;
+    }
+    state_pub_->publish(msg);
+  }
+
+  void onPairRequest(const std_msgs::msg::String::SharedPtr msg){
+    pending_device_ = msg->data;
+    publishState();
+  }
+
+  void handlePower(const std::shared_ptr<std_srvs::srv::SetBool::Request> req,
+                   std::shared_ptr<std_srvs::srv::SetBool::Response> res){
+    enabled_ = req->data;
+    if(enabled_){
+      std::system("bluetoothctl power on >/dev/null 2>&1");
+    } else {
+      std::system("bluetoothctl power off >/dev/null 2>&1");
+      pending_device_.clear();
+    }
+    publishState();
+    res->success = true;
+    res->message = enabled_ ? "ON" : "OFF";
+  }
+
+  void handlePair(const std::shared_ptr<std_srvs::srv::SetBool::Request> req,
+                  std::shared_ptr<std_srvs::srv::SetBool::Response> res){
+    if(pending_device_.empty()){
+      res->success = false;
+      res->message = "No request";
+      return;
+    }
+    if(req->data){
+      std::string cmd = std::string("bluetoothctl pair ") + pending_device_ + " >/dev/null 2>&1";
+      std::system(cmd.c_str());
+    } else {
+      std::string cmd = std::string("bluetoothctl reject ") + pending_device_ + " >/dev/null 2>&1";
+      std::system(cmd.c_str());
+    }
+    pending_device_.clear();
+    publishState();
+    res->success = true;
+    res->message = req->data ? "paired" : "rejected";
+  }
+
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr state_pub_;
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr power_srv_;
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr pair_srv_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr pair_sub_;
+  bool enabled_{false};
+  std::string pending_device_;
+};
+
+int main(int argc, char** argv){
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<BluetoothManager>());
+  rclcpp::shutdown();
+  return 0;
+}
+

--- a/src/screen/UiMenu.cpp
+++ b/src/screen/UiMenu.cpp
@@ -21,9 +21,15 @@ MenuController::Item MenuController::buildDefaultTree(){
   wifi.children.push_back({"Reject", false, MenuAction::BT_REJECT, {}});
   wifi.children.push_back({"Stop provisioning", false, MenuAction::BT_STOP, {}});
 
+  Item bt; bt.label = "Bluetooth"; bt.is_submenu = true;
+  bt.children.push_back({"Status: Off", false, MenuAction::NONE, {}});
+  bt.children.push_back({"Enable Bluetooth", false, MenuAction::BT_ON, {}});
+  bt.children.push_back({"", false, MenuAction::NONE, {}});
+  bt.children.push_back({"", false, MenuAction::NONE, {}});
+
   Item apagar; apagar.label = "Apagar"; apagar.is_submenu = false; apagar.action = MenuAction::POWEROFF;
 
-  root.children = {modos, wifi, apagar};
+  root.children = {modos, wifi, bt, apagar};
   return root;
 }
 
@@ -78,6 +84,29 @@ void MenuController::setBtState(const std::string& state, uint32_t code){
       } else {
         wifi.children[5].label = "Stop provisioning";
         wifi.children[5].action = MenuAction::BT_STOP;
+      }
+    }
+  }
+}
+
+void MenuController::setBluetoothState(bool enabled, const std::string& device){
+  if(root_.children.size() > 2){
+    Item& bt = root_.children[2];
+    if(bt.label == "Bluetooth" && bt.children.size() >= 4){
+      bt.children[0].label = std::string("Status: ") + (enabled ? "On" : "Off");
+      bt.children[0].color = enabled ? cv::Scalar(0,255,0) : cv::Scalar(0,0,255);
+      bt.children[1].label = enabled ? "Disable Bluetooth" : "Enable Bluetooth";
+      bt.children[1].action = enabled ? MenuAction::BT_OFF : MenuAction::BT_ON;
+      if(device.empty()){
+        bt.children[2].label = "";
+        bt.children[2].action = MenuAction::NONE;
+        bt.children[3].label = "";
+        bt.children[3].action = MenuAction::NONE;
+      } else {
+        bt.children[2].label = std::string("Accept ") + device;
+        bt.children[2].action = MenuAction::BT_PAIR_ACCEPT;
+        bt.children[3].label = std::string("Reject ") + device;
+        bt.children[3].action = MenuAction::BT_PAIR_REJECT;
       }
     }
   }


### PR DESCRIPTION
## Summary
- add Bluetooth top-level menu with enable/disable and pairing controls
- provide BluetoothManagerNode to manage power and pairing requests
- integrate Bluetooth services and launch configs

## Testing
- `\colcon build 2>&1 | head -n 200`
- `\colcon test 2>&1 | head -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68b1583126388321b53255afa013856b