### PR TITLE
Integrate bluetoothctl agent for pairing workflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,15 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 )
 
 # =========================================
+# Bluetoothctl agent library
+# =========================================
+add_library(robofer_bt_agent
+  src/bluetoothctl_agent.cpp
+)
+target_include_directories(robofer_bt_agent PUBLIC include)
+target_link_libraries(robofer_bt_agent PUBLIC pthread)
+
+# =========================================
 # 1) Librería de lógica de ojos
 # =========================================
 add_library(robo_eyes_lib SHARED
@@ -126,6 +135,7 @@ ament_target_dependencies(eyes_unified_node rclcpp std_msgs std_srvs)
 target_link_libraries(eyes_unified_node
   robo_eyes_lib
   robo_display
+  robofer_bt_agent
   ${OpenCV_LIBS}
 )
 rosidl_target_interfaces(eyes_unified_node
@@ -196,6 +206,7 @@ install(TARGETS
   robo_display
   robo_servos
   robo_audio
+  robofer_bt_agent
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin

--- a/include/robofer/bluetoothctl_agent.hpp
+++ b/include/robofer/bluetoothctl_agent.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include <functional>
+#include <string>
+#include <thread>
+#include <atomic>
+#include <regex>
+
+// Agente mínimo para controlar una sesión persistente de `bluetoothctl`.
+// - start(onLine): lanza bluetoothctl, redirige stdin/stdout y crea un hilo lector.
+// - send(cmd): escribe "cmd\n" al stdin del proceso.
+// - stop(): sale de bluetoothctl y limpia recursos.
+// Sugerencia: en el callback onLine parseas "Confirm passkey 123456 (yes/no)" y "Pairing successful".
+
+class BluetoothctlAgent {
+public:
+  using LineHandler = std::function<void(const std::string&)>;
+
+  BluetoothctlAgent() = default;
+  ~BluetoothctlAgent() { stop(); }
+
+  // Arranca `bluetoothctl` y comienza a leer líneas en un hilo aparte.
+  // Devuelve false si no se pudo lanzar el proceso.
+  bool start(LineHandler on_line);
+
+  // Envía un comando a bluetoothctl (se añade '\n' automáticamente).
+  void send(const std::string& cmd);
+
+  // Para el hilo lector y cierra el proceso bluetoothctl.
+  void stop();
+
+  // Atajos útiles
+  void powerOn();
+  void powerOff();
+  void enableProvisionWindow(const std::string& alias = "", int discoverable_seconds = 180);
+  void disableProvisionWindow();
+
+private:
+  int in_fd_  = -1;  // lo que ESCRIBES aquí va al stdin de bluetoothctl
+  int out_fd_ = -1;  // lo que LEES aquí viene del stdout/stderr de bluetoothctl
+  pid_t child_pid_ = -1;
+  std::thread reader_;
+  std::atomic<bool> running_{false};
+  LineHandler on_line_;
+};
+

--- a/src/bluetoothctl_agent.cpp
+++ b/src/bluetoothctl_agent.cpp
@@ -1,0 +1,132 @@
+#include "robofer/bluetoothctl_agent.hpp"
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <fcntl.h>
+#include <cstring>
+#include <iostream>
+
+namespace {
+  // Hace el fd no bloqueante (opcional, aquí lo dejamos bloqueante).
+  void set_cloexec(int fd) {
+    int flags = fcntl(fd, F_GETFD);
+    if (flags >= 0) fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+  }
+}
+
+bool BluetoothctlAgent::start(LineHandler on_line) {
+  if (running_) return true;
+
+  int to_child[2];     // padre escribe -> hijo lee (stdin)
+  int from_child[2];   // hijo escribe -> padre lee (stdout/err)
+  if (pipe(to_child) < 0 || pipe(from_child) < 0) return false;
+
+  child_pid_ = fork();
+  if (child_pid_ < 0) return false;
+
+  if (child_pid_ == 0) {
+    // ---- PROCESO HIJO ----
+    // Redirigir stdin/out/err
+    dup2(to_child[0], STDIN_FILENO);
+    dup2(from_child[1], STDOUT_FILENO);
+    dup2(from_child[1], STDERR_FILENO);
+    close(to_child[1]);
+    close(from_child[0]);
+
+    // Forzar salida en inglés para parsear mensajes de forma estable
+    setenv("LANG", "C", 1);
+    setenv("LC_ALL", "C", 1);
+
+    // Ejecutar bluetoothctl
+    execlp("bluetoothctl", "bluetoothctl", (char*)nullptr);
+    _exit(1); // Si execlp falla
+  }
+
+  // ---- PROCESO PADRE ----
+  close(to_child[0]);
+  close(from_child[1]);
+  in_fd_  = to_child[1];
+  out_fd_ = from_child[0];
+  set_cloexec(in_fd_);
+  set_cloexec(out_fd_);
+
+  on_line_ = std::move(on_line);
+  running_ = true;
+
+  reader_ = std::thread([this]() {
+    std::string buf; buf.reserve(4096);
+    char tmp[256];
+    while (running_) {
+      ssize_t n = ::read(out_fd_, tmp, sizeof(tmp));
+      if (n <= 0) break;
+      buf.append(tmp, tmp + n);
+      std::size_t pos;
+      while ((pos = buf.find('\n')) != std::string::npos) {
+        std::string line = buf.substr(0, pos);
+        buf.erase(0, pos + 1);
+        if (on_line_) on_line_(line);
+      }
+    }
+  });
+
+  return true;
+}
+
+void BluetoothctlAgent::send(const std::string& cmd) {
+  if (in_fd_ < 0) return;
+  std::string s = cmd + "\n";
+  ::write(in_fd_, s.data(), s.size());
+}
+
+void BluetoothctlAgent::stop() {
+  if (!running_) return;
+  running_ = false;
+
+  // Intenta salir de forma amable
+  if (in_fd_ >= 0) {
+    send("exit");
+    ::close(in_fd_);
+    in_fd_ = -1;
+  }
+  if (out_fd_ >= 0) {
+    ::close(out_fd_);
+    out_fd_ = -1;
+  }
+  if (reader_.joinable()) reader_.join();
+
+  if (child_pid_ > 0) {
+    int st = 0;
+    waitpid(child_pid_, &st, 0);
+    child_pid_ = -1;
+  }
+}
+
+void BluetoothctlAgent::powerOn() {
+  send("power on");
+}
+
+void BluetoothctlAgent::powerOff() {
+  send("power off");
+}
+
+void BluetoothctlAgent::enableProvisionWindow(const std::string& alias, int discoverable_seconds) {
+  if (!alias.empty()) {
+    send("system-alias " + alias); // en algunas versiones es 'system-alias' o 'set-alias'
+    // Si tu bluetoothctl no soporta system-alias, ignora esta línea.
+  }
+  send("agent DisplayYesNo");
+  send("default-agent");
+  send("pairable on");
+  send("discoverable on");
+
+  // algunos bluetoothctl soportan 'discoverable-timeout <s>'
+  if (discoverable_seconds > 0) {
+    send("discoverable-timeout " + std::to_string(discoverable_seconds));
+  }
+}
+
+void BluetoothctlAgent::disableProvisionWindow() {
+  send("discoverable off");
+  send("pairable off");
+}
+

--- a/src/screen/EyesUnifiedNode.cpp
+++ b/src/screen/EyesUnifiedNode.cpp
@@ -1,15 +1,14 @@
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/int32.hpp>
 #include <std_msgs/msg/u_int8.hpp>
-#include <std_srvs/srv/trigger.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <std_srvs/srv/set_bool.hpp>
-#include "robofer/srv/set_bool_with_code.hpp"
+#include <regex>
+#include "robofer/bluetoothctl_agent.hpp"
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
 #include <mutex>
 #include <algorithm>
-#include <atomic>
 
 #include "robofer/screen/Eyes.hpp"
 #include "robofer/screen/Display.hpp"
@@ -23,108 +22,6 @@ using robo_ui::MenuAction;
 using robo_ui::UiKey;
 
 static const char* NODE_NAME = "robo_eyes";
-
-struct ActionDispatcher {
-  rclcpp::Logger log;
-  rclcpp::Publisher<std_msgs::msg::UInt8>::SharedPtr mode_pub;
-  rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr bt_start_client;
-  rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr bt_stop_client;
-  rclcpp::Client<robofer::srv::SetBoolWithCode>::SharedPtr bt_confirm_client;
-  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr bt_power_client;
-  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr bt_pair_client;
-  std::atomic<uint32_t>* pending_code;
-  void operator()(MenuAction a){
-    std_msgs::msg::UInt8 m;
-    switch(a){
-      case MenuAction::SET_ANGRY:
-        m.data = static_cast<uint8_t>(Mood::ANGRY);
-        mode_pub->publish(m);
-        RCLCPP_INFO(log, "MenuAction -> mode ANGRY");
-        break;
-      case MenuAction::SET_SAD:
-        m.data = static_cast<uint8_t>(Mood::FROWN);
-        mode_pub->publish(m);
-        RCLCPP_INFO(log, "MenuAction -> mode SAD");
-        break;
-      case MenuAction::SET_HAPPY:
-        m.data = static_cast<uint8_t>(Mood::HAPPY);
-        mode_pub->publish(m);
-        RCLCPP_INFO(log, "MenuAction -> mode HAPPY");
-        break;
-      case MenuAction::POWEROFF:
-        RCLCPP_WARN(log, "MenuAction: POWEROFF (llamando a sudo poweroff)");
-        std::system("sudo poweroff &");
-        break;
-      case MenuAction::BT_CONNECT:
-        RCLCPP_INFO(log, "MenuAction: BT_CONNECT");
-        if(bt_start_client){
-          auto req = std::make_shared<std_srvs::srv::Trigger::Request>();
-          bt_start_client->async_send_request(req);
-        }
-        break;
-      case MenuAction::BT_STOP:
-        RCLCPP_INFO(log, "MenuAction: BT_STOP");
-        if(bt_stop_client){
-          auto req = std::make_shared<std_srvs::srv::Trigger::Request>();
-          bt_stop_client->async_send_request(req);
-        }
-        break;
-      case MenuAction::BT_ACCEPT:
-        RCLCPP_INFO(log, "MenuAction: BT_ACCEPT");
-        if(bt_confirm_client && pending_code){
-          auto req = std::make_shared<robofer::srv::SetBoolWithCode::Request>();
-          req->accept = true;
-          req->code = pending_code->load();
-          bt_confirm_client->async_send_request(req);
-        }
-        break;
-      case MenuAction::BT_REJECT:
-        RCLCPP_INFO(log, "MenuAction: BT_REJECT");
-        if(bt_confirm_client && pending_code){
-          auto req = std::make_shared<robofer::srv::SetBoolWithCode::Request>();
-          req->accept = false;
-          req->code = pending_code->load();
-          bt_confirm_client->async_send_request(req);
-        }
-        break;
-      case MenuAction::BT_ON:
-        RCLCPP_INFO(log, "MenuAction: BT_ON");
-        if(bt_power_client){
-          auto req = std::make_shared<std_srvs::srv::SetBool::Request>();
-          req->data = true;
-          bt_power_client->async_send_request(req);
-        }
-        break;
-      case MenuAction::BT_OFF:
-        RCLCPP_INFO(log, "MenuAction: BT_OFF");
-        if(bt_power_client){
-          auto req = std::make_shared<std_srvs::srv::SetBool::Request>();
-          req->data = false;
-          bt_power_client->async_send_request(req);
-        }
-        break;
-      case MenuAction::BT_PAIR_ACCEPT:
-        RCLCPP_INFO(log, "MenuAction: BT_PAIR_ACCEPT");
-        if(bt_pair_client){
-          auto req = std::make_shared<std_srvs::srv::SetBool::Request>();
-          req->data = true;
-          bt_pair_client->async_send_request(req);
-        }
-        break;
-      case MenuAction::BT_PAIR_REJECT:
-        RCLCPP_INFO(log, "MenuAction: BT_PAIR_REJECT");
-        if(bt_pair_client){
-          auto req = std::make_shared<std_srvs::srv::SetBool::Request>();
-          req->data = false;
-          bt_pair_client->async_send_request(req);
-        }
-        break;
-      case MenuAction::NONE:
-      default:
-        break;
-    }
-  }
-};
 
 int main(int argc, char** argv){
   rclcpp::init(argc, argv);
@@ -152,15 +49,124 @@ int main(int argc, char** argv){
   eyes.setMood(Mood::DEFAULT);
 
   auto mode_pub = node->create_publisher<std_msgs::msg::UInt8>("/mode", 10);
-  auto bt_start_client = node->create_client<std_srvs::srv::Trigger>("/wifi_prov/start");
-  auto bt_stop_client  = node->create_client<std_srvs::srv::Trigger>("/wifi_prov/stop");
-  auto bt_confirm_client = node->create_client<robofer::srv::SetBoolWithCode>("/wifi_prov/confirm");
   auto bt_power_client = node->create_client<std_srvs::srv::SetBool>("/bluetooth/power");
   auto bt_pair_client  = node->create_client<std_srvs::srv::SetBool>("/bluetooth/pair_response");
-  std::atomic<uint32_t> pending_code{0};
-  ActionDispatcher dispatch{ log, mode_pub, bt_start_client, bt_stop_client, bt_confirm_client, bt_power_client, bt_pair_client, &pending_code };
-  MenuController   menu([&](MenuAction a){ dispatch(a); });
+
+  BluetoothctlAgent bt_agent;
+  std::string last_passkey;
+  enum class BtUiState { IDLE, STARTING, WAITING_CONFIRM, PAIRED, SPP_READY, CONNECTED, ERROR_ };
+  BtUiState bt_state = BtUiState::IDLE;
+  MenuController* menu_ptr = nullptr;
+  auto update_bt_menu = [&](){
+    if(!menu_ptr) return;
+    std::string st; uint32_t code = 0;
+    switch(bt_state){
+      case BtUiState::IDLE: st = "IDLE"; break;
+      case BtUiState::STARTING: st = "STARTING"; break;
+      case BtUiState::WAITING_CONFIRM: st = std::string("CONFIRM_CODE:") + last_passkey; code = static_cast<uint32_t>(std::stoul(last_passkey)); break;
+      case BtUiState::PAIRED: st = "PAIRED"; break;
+      case BtUiState::SPP_READY: st = "SPP_READY"; break;
+      case BtUiState::CONNECTED: st = "CONNECTED"; break;
+      case BtUiState::ERROR_: st = "ERROR"; break;
+    }
+    menu_ptr->setBtState(st, code);
+  };
+
+  MenuController menu([&](MenuAction a){
+    std_msgs::msg::UInt8 m;
+    switch(a){
+      case MenuAction::SET_ANGRY:
+        m.data = static_cast<uint8_t>(Mood::ANGRY);
+        mode_pub->publish(m);
+        RCLCPP_INFO(log, "MenuAction -> mode ANGRY");
+        break;
+      case MenuAction::SET_SAD:
+        m.data = static_cast<uint8_t>(Mood::FROWN);
+        mode_pub->publish(m);
+        RCLCPP_INFO(log, "MenuAction -> mode SAD");
+        break;
+      case MenuAction::SET_HAPPY:
+        m.data = static_cast<uint8_t>(Mood::HAPPY);
+        mode_pub->publish(m);
+        RCLCPP_INFO(log, "MenuAction -> mode HAPPY");
+        break;
+      case MenuAction::POWEROFF:
+        RCLCPP_WARN(log, "MenuAction: POWEROFF (llamando a sudo poweroff)");
+        std::system("sudo poweroff &");
+        break;
+      case MenuAction::BT_CONNECT: {
+        RCLCPP_INFO(log, "MenuAction: BT_CONNECT");
+        bt_state = BtUiState::STARTING;
+        update_bt_menu();
+        bool ok = bt_agent.start([&](const std::string& line){
+          static const std::regex re_passkey(".*Confirm passkey\\s+(\\d{6}).*yes/no.*");
+          std::smatch m;
+          if(std::regex_match(line, m, re_passkey)){
+            last_passkey = m[1];
+            bt_state = BtUiState::WAITING_CONFIRM;
+            update_bt_menu();
+            return;
+          }
+          if(line.find("Pairing successful") != std::string::npos ||
+             line.find(" Paired: yes") != std::string::npos){
+            bt_agent.disableProvisionWindow();
+            std::system("sdptool add --channel=3 SP >/dev/null 2>&1");
+            bt_state = BtUiState::PAIRED;
+            update_bt_menu();
+            return;
+          }
+          if(line.find("Failed") != std::string::npos || line.find("Error") != std::string::npos){
+            bt_state = BtUiState::ERROR_;
+            update_bt_menu();
+          }
+        });
+        if(!ok){
+          bt_state = BtUiState::ERROR_;
+          update_bt_menu();
+          break;
+        }
+        bt_agent.powerOn();
+        bt_agent.enableProvisionWindow("Robofer", 180);
+        break; }
+      case MenuAction::BT_STOP:
+        RCLCPP_INFO(log, "MenuAction: BT_STOP");
+        bt_agent.disableProvisionWindow();
+        bt_agent.stop();
+        bt_state = BtUiState::IDLE;
+        update_bt_menu();
+        break;
+      case MenuAction::BT_ACCEPT:
+        RCLCPP_INFO(log, "MenuAction: BT_ACCEPT");
+        if(bt_state == BtUiState::WAITING_CONFIRM) bt_agent.send("yes");
+        break;
+      case MenuAction::BT_REJECT:
+        RCLCPP_INFO(log, "MenuAction: BT_REJECT");
+        if(bt_state == BtUiState::WAITING_CONFIRM) bt_agent.send("no");
+        break;
+      case MenuAction::BT_ON:
+        RCLCPP_INFO(log, "MenuAction: BT_ON");
+        if(bt_power_client){ auto req = std::make_shared<std_srvs::srv::SetBool::Request>(); req->data = true; bt_power_client->async_send_request(req); }
+        break;
+      case MenuAction::BT_OFF:
+        RCLCPP_INFO(log, "MenuAction: BT_OFF");
+        if(bt_power_client){ auto req = std::make_shared<std_srvs::srv::SetBool::Request>(); req->data = false; bt_power_client->async_send_request(req); }
+        break;
+      case MenuAction::BT_PAIR_ACCEPT:
+        RCLCPP_INFO(log, "MenuAction: BT_PAIR_ACCEPT");
+        if(bt_pair_client){ auto req = std::make_shared<std_srvs::srv::SetBool::Request>(); req->data = true; bt_pair_client->async_send_request(req); }
+        break;
+      case MenuAction::BT_PAIR_REJECT:
+        RCLCPP_INFO(log, "MenuAction: BT_PAIR_REJECT");
+        if(bt_pair_client){ auto req = std::make_shared<std_srvs::srv::SetBool::Request>(); req->data = false; bt_pair_client->async_send_request(req); }
+        break;
+      case MenuAction::NONE:
+      default:
+        break;
+    }
+  });
+  menu_ptr = &menu;
   menu.setTimeoutMs(menu_timeout_ms);
+  update_bt_menu();
 
   std::mutex ui_mtx;
   auto sub_ui = node->create_subscription<std_msgs::msg::Int32>(
@@ -192,19 +198,6 @@ int main(int argc, char** argv){
     [&](const robofer::msg::WifiStatus::SharedPtr msg){
       std::lock_guard<std::mutex> lk(ui_mtx);
       menu.setWifiStatus(msg->connected, msg->ssid);
-    });
-
-  auto prov_sub = node->create_subscription<std_msgs::msg::String>(
-    "/wifi_prov/state", 10,
-    [&](const std_msgs::msg::String::SharedPtr msg){
-      std::lock_guard<std::mutex> lk(ui_mtx);
-      uint32_t code = 0;
-      std::string st = msg->data;
-      if(st.rfind("CONFIRM_CODE:",0)==0){
-        code = static_cast<uint32_t>(std::stoul(st.substr(13)));
-      }
-      pending_code.store(code);
-      menu.setBtState(st, code);
     });
 
   auto bt_state_sub = node->create_subscription<std_msgs::msg::String>(


### PR DESCRIPTION
## Summary
- add BluetoothctlAgent to manage persistent bluetoothctl session
- hook Bluetooth provisioning into EyesUnifiedNode menu
- build and link new bluetooth agent library

## Testing
- `which python3`
- `python3 -V`
- `python3 -c "import em"`
- `\colcon build 2>&1 | head -n 200`
- `\colcon test 2>&1 | head -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68b15eef195c8321898a949a0b950320