### PR TITLE
Enable Bluetooth pairing agent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,8 @@ add_executable(bluetooth_manager_node
   src/network/BluetoothManagerNode.cpp
 )
 ament_target_dependencies(bluetooth_manager_node rclcpp std_msgs std_srvs)
+target_link_libraries(bluetooth_manager_node
+  robofer_bt_agent)
 rosidl_target_interfaces(bluetooth_manager_node
   ${PROJECT_NAME} "rosidl_typesupport_cpp")
 


### PR DESCRIPTION
## Summary
- manage Bluetooth with a persistent bluetoothctl agent
- support passkey confirmation and pairable/discoverable mode
- link bluetooth manager with bluetooth agent library

## Testing
- `\colcon build 2>&1 | head -n 200`
- `\colcon test 2>&1 | head -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68b1762565f88321a79cf76a392e633d