### PR TITLE
Default ST7735 landscape orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ estado internamente a través de `/ui/button`.
 * `gpiochip_c` (`gpiochip0`)
 * `dc_offset=75`, `rst_offset=78`, `cs_offset=233` (ejemplo OPI Zero 3)
 * `spi_chunk=2048`
-* `madctl=0x00`, `invert=false`, `self_test=true`
+* `madctl=0x60`, `invert=false`, `self_test=true`
 
 **buttons_node**
 
@@ -198,7 +198,7 @@ ros2 launch robofer eyes_system.launch.py sim:=false \
   spi_device:=/dev/spidev1.0 spi_hz:=24000000 spi_chunk:=2048 \
   use_manual_cs:=true gpiochip_c:=gpiochip0 \
   dc_offset:=75 rst_offset:=78 cs_offset:=233 \
-  madctl:=0 invert:=false self_test:=true \
+  madctl:=96 invert:=false self_test:=true \
   btn1_offset:=66 btn2_offset:=67 btn3_offset:=71 btn4_offset:=72
 ```
 

--- a/launch/eyes_system.launch.py
+++ b/launch/eyes_system.launch.py
@@ -153,7 +153,7 @@ def generate_launch_description():
     ld.add_action(DeclareLaunchArgument('rst_offset', default_value='78'))
     ld.add_action(DeclareLaunchArgument('cs_offset', default_value='233'))
     ld.add_action(DeclareLaunchArgument('spi_chunk', default_value='2048'))
-    ld.add_action(DeclareLaunchArgument('madctl', default_value='0'))
+    ld.add_action(DeclareLaunchArgument('madctl', default_value='96'))
     ld.add_action(DeclareLaunchArgument('invert', default_value='false'))
     ld.add_action(DeclareLaunchArgument('self_test', default_value='true'))
 

--- a/src/screen/Display.cpp
+++ b/src/screen/Display.cpp
@@ -105,7 +105,7 @@ public:
     lcd_h_        = node.declare_parameter<int>("lcd_height", 160);
     x_off_        = node.declare_parameter<int>("x_offset", 0);
     y_off_        = node.declare_parameter<int>("y_offset", 0);
-    madctl_       = uint8_t(node.declare_parameter<int>("madctl", 0x00));
+    madctl_       = uint8_t(node.declare_parameter<int>("madctl", 0x60));
     invert_       = node.declare_parameter<bool>("invert", false);
     self_test_    = node.declare_parameter<bool>("self_test", true);
     spi_chunk_    = (size_t)node.declare_parameter<int>("spi_chunk", 2048);
@@ -115,6 +115,12 @@ public:
     dc_offset_    = node.declare_parameter<int>("dc_offset", 75);
     rst_offset_   = node.declare_parameter<int>("rst_offset", 78);
     cs_offset_    = node.declare_parameter<int>("cs_offset", 233);
+
+    // Si el bit MV está activo, la pantalla rota 90° y se intercambian ancho/alto
+    if(madctl_ & 0x20) {
+      std::swap(lcd_w_, lcd_h_);
+      std::swap(x_off_, y_off_);
+    }
 
     // ====== Inicialización HW ======
     if(!dc_.request(gpiochip_c_.c_str(), dc_offset_, 0) ||
@@ -354,7 +360,7 @@ private:
   int         spi_hz_{24000000};
   int         lcd_w_{128}, lcd_h_{160};
   int         x_off_{0}, y_off_{0};
-  uint8_t     madctl_{0x00};
+  uint8_t     madctl_{0x60};
   bool        invert_{false};
   bool        self_test_{true};
   size_t      spi_chunk_{2048};

--- a/src/screen/EyesSt7735Node.cpp
+++ b/src/screen/EyesSt7735Node.cpp
@@ -51,7 +51,7 @@ struct St7735 {
   GpioLine dc, rst, cs;        // DC, RESET y (opcional) CS manual
   bool use_manual_cs = true;
   uint16_t w=128, h=160;
-  uint8_t  madctl = 0x00;      // orientación
+  uint8_t  madctl = 0x60;      // orientación
   uint16_t xofs=0, yofs=0;     // offsets
   bool invert=false;
   size_t spi_chunk = 4096;     // tamaño máx. por write()
@@ -253,7 +253,7 @@ int main(int argc, char** argv){
   int lcd_h = node->declare_parameter<int>("lcd_height", 160);
   int x_off = node->declare_parameter<int>("x_offset", 0);
   int y_off = node->declare_parameter<int>("y_offset", 0);
-  int mad   = node->declare_parameter<int>("madctl", 0x00);
+  int mad   = node->declare_parameter<int>("madctl", 0x60);
   bool invert = node->declare_parameter<bool>("invert", false);
   bool self_test = node->declare_parameter<bool>("self_test", true);
   int spi_chunk = node->declare_parameter<int>("spi_chunk", 2048);
@@ -263,6 +263,11 @@ int main(int argc, char** argv){
   int dc_offset  = node->declare_parameter<int>("dc_offset", 75);   // PC11 -> pin 12
   int rst_offset = node->declare_parameter<int>("rst_offset", 78);  // PC14 -> pin 18
   int cs_offset  = node->declare_parameter<int>("cs_offset", 233);  // PH9  -> pin 24 (CS manual)
+
+  if(mad & 0x20) {
+    std::swap(lcd_w, lcd_h);
+    std::swap(x_off, y_off);
+  }
 
   RCLCPP_INFO(log, "Params: spi=%s hz=%d lcd=%dx%d off(%d,%d) madctl=0x%02X invert=%s chunk=%d CS=%s dc=%d rst=%d cs=%d chip=%s",
               spi_dev.c_str(), spi_hz, lcd_w, lcd_h, x_off, y_off, mad, invert?"ON":"OFF",


### PR DESCRIPTION
## Summary
- Default ST7735 driver orientation to landscape (MADCTL 0x60)
- Swap LCD dimensions automatically when rotating
- Update launch and docs for new default

## Testing
- `set -euo pipefail; source /opt/ros/jazzy/setup.bash; export PATH=$(printf "%s" "$PATH" | tr ":" "\n" | grep -v -E "\.pyenv/shims" | paste -sd: -); hash -r; which python3; python3 -V; python3 -c "import em"; \colcon build 2>&1 | head -n 200; \colcon test 2>&1 | head -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68b1765b94d88321a1dee72991f85477