### PR TITLE
Set horizontal display orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ estado internamente a través de `/ui/button`.
 **eyes_unified_node**
 
 * `backend`: `"sim"` o `"st7735"`.
-* `eyes_width` / `eyes_height`: tamaño base de los ojos (por defecto 128×64).
+* `eyes_width` / `eyes_height`: tamaño base de los ojos (por defecto 160×128).
 * `fps`: frames por segundo (p. ej. 30 o 60).
 * `menu_timeout_ms`: overlay activo tras última tecla (por defecto 5000).
 
@@ -97,7 +97,7 @@ estado internamente a través de `/ui/button`.
 * `gpiochip_c` (`gpiochip0`)
 * `dc_offset=75`, `rst_offset=78`, `cs_offset=233` (ejemplo OPI Zero 3)
 * `spi_chunk=2048`
-* `madctl=0x60`, `invert=false`, `self_test=true`
+* `madctl=0xA0`, `invert=false`, `self_test=true`
 
 **buttons_node**
 
@@ -198,7 +198,7 @@ ros2 launch robofer eyes_system.launch.py sim:=false \
   spi_device:=/dev/spidev1.0 spi_hz:=24000000 spi_chunk:=2048 \
   use_manual_cs:=true gpiochip_c:=gpiochip0 \
   dc_offset:=75 rst_offset:=78 cs_offset:=233 \
-  madctl:=96 invert:=false self_test:=true \
+  madctl:=160 invert:=false self_test:=true \
   btn1_offset:=66 btn2_offset:=67 btn3_offset:=71 btn4_offset:=72
 ```
 

--- a/launch/eyes_system.launch.py
+++ b/launch/eyes_system.launch.py
@@ -139,8 +139,8 @@ def generate_launch_description():
     # Args
     ld.add_action(DeclareLaunchArgument('sim', default_value='true'))
 
-    ld.add_action(DeclareLaunchArgument('eyes_width', default_value='128'))
-    ld.add_action(DeclareLaunchArgument('eyes_height', default_value='64'))
+    ld.add_action(DeclareLaunchArgument('eyes_width', default_value='160'))
+    ld.add_action(DeclareLaunchArgument('eyes_height', default_value='128'))
     ld.add_action(DeclareLaunchArgument('fps', default_value='30'))
     ld.add_action(DeclareLaunchArgument('menu_timeout_ms', default_value='5000'))
 
@@ -153,7 +153,7 @@ def generate_launch_description():
     ld.add_action(DeclareLaunchArgument('rst_offset', default_value='78'))
     ld.add_action(DeclareLaunchArgument('cs_offset', default_value='233'))
     ld.add_action(DeclareLaunchArgument('spi_chunk', default_value='2048'))
-    ld.add_action(DeclareLaunchArgument('madctl', default_value='96'))
+    ld.add_action(DeclareLaunchArgument('madctl', default_value='160'))
     ld.add_action(DeclareLaunchArgument('invert', default_value='false'))
     ld.add_action(DeclareLaunchArgument('self_test', default_value='true'))
 

--- a/src/screen/Display.cpp
+++ b/src/screen/Display.cpp
@@ -105,7 +105,7 @@ public:
     lcd_h_        = node.declare_parameter<int>("lcd_height", 160);
     x_off_        = node.declare_parameter<int>("x_offset", 0);
     y_off_        = node.declare_parameter<int>("y_offset", 0);
-    madctl_       = uint8_t(node.declare_parameter<int>("madctl", 0x60));
+    madctl_       = uint8_t(node.declare_parameter<int>("madctl", 0xA0));
     invert_       = node.declare_parameter<bool>("invert", false);
     self_test_    = node.declare_parameter<bool>("self_test", true);
     spi_chunk_    = (size_t)node.declare_parameter<int>("spi_chunk", 2048);
@@ -360,7 +360,7 @@ private:
   int         spi_hz_{24000000};
   int         lcd_w_{128}, lcd_h_{160};
   int         x_off_{0}, y_off_{0};
-  uint8_t     madctl_{0x60};
+  uint8_t     madctl_{0xA0};
   bool        invert_{false};
   bool        self_test_{true};
   size_t      spi_chunk_{2048};

--- a/src/screen/EyesSt7735Node.cpp
+++ b/src/screen/EyesSt7735Node.cpp
@@ -51,7 +51,7 @@ struct St7735 {
   GpioLine dc, rst, cs;        // DC, RESET y (opcional) CS manual
   bool use_manual_cs = true;
   uint16_t w=128, h=160;
-  uint8_t  madctl = 0x60;      // orientación
+  uint8_t  madctl = 0xA0;      // orientación
   uint16_t xofs=0, yofs=0;     // offsets
   bool invert=false;
   size_t spi_chunk = 4096;     // tamaño máx. por write()
@@ -253,7 +253,7 @@ int main(int argc, char** argv){
   int lcd_h = node->declare_parameter<int>("lcd_height", 160);
   int x_off = node->declare_parameter<int>("x_offset", 0);
   int y_off = node->declare_parameter<int>("y_offset", 0);
-  int mad   = node->declare_parameter<int>("madctl", 0x60);
+  int mad   = node->declare_parameter<int>("madctl", 0xA0);
   bool invert = node->declare_parameter<bool>("invert", false);
   bool self_test = node->declare_parameter<bool>("self_test", true);
   int spi_chunk = node->declare_parameter<int>("spi_chunk", 2048);

--- a/src/screen/EyesUnifiedNode.cpp
+++ b/src/screen/EyesUnifiedNode.cpp
@@ -29,8 +29,8 @@ int main(int argc, char** argv){
   auto log = node->get_logger();
 
   std::string backend = node->declare_parameter<std::string>("backend", "st7735");
-  const int   eyes_w  = node->declare_parameter<int>("eyes_width",  128);
-  const int   eyes_h  = node->declare_parameter<int>("eyes_height", 64);
+  const int   eyes_w  = node->declare_parameter<int>("eyes_width",  160);
+  const int   eyes_h  = node->declare_parameter<int>("eyes_height", 128);
   const int   fps     = node->declare_parameter<int>("fps", 30);
   const int   menu_timeout_ms = node->declare_parameter<int>("menu_timeout_ms", 5000);
 


### PR DESCRIPTION
## Summary
- default eyes configuration to 160x128 and rotate ST7735 to horizontal (MADCTL 0xA0)
- update documentation for new screen orientation

## Testing
- `which python3`
- `python3 -V`
- `\colcon build 2>&1 | head -n 200`
- `\colcon test 2>&1 | head -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68b1807d139083218f82edfaef6e4296