### PR TITLE
Show Bluetooth pairing PIN in Robofer menu

### DIFF
--- a/src/network/BluetoothManagerNode.cpp
+++ b/src/network/BluetoothManagerNode.cpp
@@ -42,9 +42,11 @@ private:
     enabled_ = req->data;
     if(enabled_){
       bool ok = agent_.start([this](const std::string& line){
-        static const std::regex re_passkey(".*Confirm passkey\\s+(\\d{6}).*yes/no.*");
+        static const std::regex re_passkey(
+            "(?:confirm|request).*?(?:passkey|pin(?:\\s+code)?)\\D*(\\d{4,6})",
+            std::regex::icase);
         std::smatch m;
-        if(std::regex_match(line, m, re_passkey)){
+        if(std::regex_search(line, m, re_passkey)){
           {
             std::lock_guard<std::mutex> lk(mtx_);
             pending_code_ = m[1];

--- a/src/screen/EyesUnifiedNode.cpp
+++ b/src/screen/EyesUnifiedNode.cpp
@@ -99,9 +99,11 @@ int main(int argc, char** argv){
         bt_state = BtUiState::STARTING;
         update_bt_menu();
         bool ok = bt_agent.start([&](const std::string& line){
-          static const std::regex re_passkey(".*Confirm passkey\\s+(\\d{6}).*yes/no.*");
+          static const std::regex re_passkey(
+              "(?:confirm|request).*?(?:passkey|pin(?:\\s+code)?)\\D*(\\d{4,6})",
+              std::regex::icase);
           std::smatch m;
-          if(std::regex_match(line, m, re_passkey)){
+          if(std::regex_search(line, m, re_passkey)){
             last_passkey = m[1];
             bt_state = BtUiState::WAITING_CONFIRM;
             update_bt_menu();

--- a/src/screen/UiMenu.cpp
+++ b/src/screen/UiMenu.cpp
@@ -26,6 +26,7 @@ MenuController::Item MenuController::buildDefaultTree(){
   bt.children.push_back({"Enable Bluetooth", false, MenuAction::BT_ON, {}});
   bt.children.push_back({"", false, MenuAction::NONE, {}});
   bt.children.push_back({"", false, MenuAction::NONE, {}});
+  bt.children.push_back({"", false, MenuAction::NONE, {}});
 
   Item apagar; apagar.label = "Apagar"; apagar.is_submenu = false; apagar.action = MenuAction::POWEROFF;
 
@@ -92,7 +93,7 @@ void MenuController::setBtState(const std::string& state, uint32_t code){
 void MenuController::setBluetoothState(bool enabled, const std::string& device){
   if(root_.children.size() > 2){
     Item& bt = root_.children[2];
-    if(bt.label == "Bluetooth" && bt.children.size() >= 4){
+    if(bt.label == "Bluetooth" && bt.children.size() >= 5){
       bt.children[0].label = std::string("Status: ") + (enabled ? "On" : "Off");
       bt.children[0].color = enabled ? cv::Scalar(0,255,0) : cv::Scalar(0,0,255);
       bt.children[1].label = enabled ? "Disable Bluetooth" : "Enable Bluetooth";
@@ -102,11 +103,15 @@ void MenuController::setBluetoothState(bool enabled, const std::string& device){
         bt.children[2].action = MenuAction::NONE;
         bt.children[3].label = "";
         bt.children[3].action = MenuAction::NONE;
+        bt.children[4].label = "";
+        bt.children[4].action = MenuAction::NONE;
       } else {
-        bt.children[2].label = std::string("Accept ") + device;
-        bt.children[2].action = MenuAction::BT_PAIR_ACCEPT;
-        bt.children[3].label = std::string("Reject ") + device;
-        bt.children[3].action = MenuAction::BT_PAIR_REJECT;
+        bt.children[2].label = std::string("PIN: ") + device;
+        bt.children[2].action = MenuAction::NONE;
+        bt.children[3].label = "Accept";
+        bt.children[3].action = MenuAction::BT_PAIR_ACCEPT;
+        bt.children[4].label = "Reject";
+        bt.children[4].action = MenuAction::BT_PAIR_REJECT;
       }
     }
   }


### PR DESCRIPTION
## Summary
- Detect Bluetooth pairing passkeys from bluetoothctl output in a case-insensitive way
- Display pairing PIN with Accept/Reject options in the Bluetooth submenu
- Update pairing provisioning logic to use the same robust passkey detection

## Testing
- `\colcon build 2>&1 | head -n 200`
- `\colcon test 2>&1 | head -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68b188b9575083218b12ad6312fee955