### PR TITLE
Add verbose Bluetooth logging for pairing diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,8 @@ add_library(robofer_bt_agent
   src/bluetoothctl_agent.cpp
 )
 target_include_directories(robofer_bt_agent PUBLIC include)
-target_link_libraries(robofer_bt_agent PUBLIC pthread)
+ament_target_dependencies(robofer_bt_agent rclcpp)
+target_link_libraries(robofer_bt_agent pthread)
 
 # =========================================
 # 1) Librería de lógica de ojos

--- a/src/bluetoothctl_agent.cpp
+++ b/src/bluetoothctl_agent.cpp
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <cstring>
 #include <iostream>
+#include <rclcpp/rclcpp.hpp>
 
 namespace {
   // Hace el fd no bloqueante (opcional, aquí lo dejamos bloqueante).
@@ -15,14 +16,24 @@ namespace {
 }
 
 bool BluetoothctlAgent::start(LineHandler on_line) {
-  if (running_) return true;
+  static auto logger = rclcpp::get_logger("BluetoothctlAgent");
+  if (running_) {
+    RCLCPP_INFO(logger, "Agent already running");
+    return true;
+  }
 
   int to_child[2];     // padre escribe -> hijo lee (stdin)
   int from_child[2];   // hijo escribe -> padre lee (stdout/err)
-  if (pipe(to_child) < 0 || pipe(from_child) < 0) return false;
+  if (pipe(to_child) < 0 || pipe(from_child) < 0) {
+    RCLCPP_INFO(logger, "pipe() failed");
+    return false;
+  }
 
   child_pid_ = fork();
-  if (child_pid_ < 0) return false;
+  if (child_pid_ < 0) {
+    RCLCPP_INFO(logger, "fork() failed");
+    return false;
+  }
 
   if (child_pid_ == 0) {
     // ---- PROCESO HIJO ----
@@ -53,7 +64,7 @@ bool BluetoothctlAgent::start(LineHandler on_line) {
   on_line_ = std::move(on_line);
   running_ = true;
 
-  reader_ = std::thread([this]() {
+  reader_ = std::thread([this, logger]() {
     std::string buf; buf.reserve(4096);
     char tmp[256];
     while (running_) {
@@ -64,23 +75,32 @@ bool BluetoothctlAgent::start(LineHandler on_line) {
       while ((pos = buf.find('\n')) != std::string::npos) {
         std::string line = buf.substr(0, pos);
         buf.erase(0, pos + 1);
+        RCLCPP_INFO(logger, "[btctl] %s", line.c_str());
         if (on_line_) on_line_(line);
       }
     }
   });
 
+  RCLCPP_INFO(logger, "bluetoothctl process started (pid %d)", child_pid_);
   return true;
 }
 
 void BluetoothctlAgent::send(const std::string& cmd) {
-  if (in_fd_ < 0) return;
+  static auto logger = rclcpp::get_logger("BluetoothctlAgent");
+  if (in_fd_ < 0) {
+    RCLCPP_INFO(logger, "send() ignored, no pipe");
+    return;
+  }
   std::string s = cmd + "\n";
+  RCLCPP_INFO(logger, "send: %s", cmd.c_str());
   ::write(in_fd_, s.data(), s.size());
 }
 
 void BluetoothctlAgent::stop() {
+  static auto logger = rclcpp::get_logger("BluetoothctlAgent");
   if (!running_) return;
   running_ = false;
+  RCLCPP_INFO(logger, "Stopping agent");
 
   // Intenta salir de forma amable
   if (in_fd_ >= 0) {
@@ -99,6 +119,7 @@ void BluetoothctlAgent::stop() {
     waitpid(child_pid_, &st, 0);
     child_pid_ = -1;
   }
+  RCLCPP_INFO(logger, "Agent stopped");
 }
 
 void BluetoothctlAgent::powerOn() {
@@ -110,6 +131,8 @@ void BluetoothctlAgent::powerOff() {
 }
 
 void BluetoothctlAgent::enableProvisionWindow(const std::string& alias, int discoverable_seconds) {
+  static auto logger = rclcpp::get_logger("BluetoothctlAgent");
+  RCLCPP_INFO(logger, "Enabling provision window alias='%s' timeout=%d", alias.c_str(), discoverable_seconds);
   if (!alias.empty()) {
     send("system-alias " + alias); // en algunas versiones es 'system-alias' o 'set-alias'
     // Si tu bluetoothctl no soporta system-alias, ignora esta línea.
@@ -126,6 +149,8 @@ void BluetoothctlAgent::enableProvisionWindow(const std::string& alias, int disc
 }
 
 void BluetoothctlAgent::disableProvisionWindow() {
+  static auto logger = rclcpp::get_logger("BluetoothctlAgent");
+  RCLCPP_INFO(logger, "Disabling provision window");
   send("discoverable off");
   send("pairable off");
 }


### PR DESCRIPTION
## Summary
- add detailed RCLCPP_INFO logs to BluetoothManager for state and pairing events
- instrument bluetoothctl agent with logging and link against rclcpp

## Testing
- `\colcon build 2>&1 | head -n 200`
- `\colcon test 2>&1 | head -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68b18e2cb384832192cc78c97e65778b