### PR TITLE
Wire up MusicMenu for playable tracks

### DIFF
--- a/include/robofer/screen/UiMenu.hpp
+++ b/include/robofer/screen/UiMenu.hpp
@@ -30,6 +30,7 @@ enum class MenuAction {
   BT_OFF,
   BT_PAIR_ACCEPT,
   BT_PAIR_REJECT,
+  MUSIC_MENU,
 };
 
 /**

--- a/src/screen/UiMenu.cpp
+++ b/src/screen/UiMenu.cpp
@@ -28,8 +28,7 @@ MenuController::Item MenuController::buildDefaultTree(){
   bt.children.push_back({"", false, MenuAction::NONE, {}});
   bt.children.push_back({"", false, MenuAction::NONE, {}});
 
-  Item music; music.label = "Music"; music.is_submenu = true;
-  music.children.push_back({"None", false, MenuAction::NONE, {}});
+  Item music; music.label = "Music"; music.is_submenu = false; music.action = MenuAction::MUSIC_MENU;
 
   Item apagar; apagar.label = "Apagar"; apagar.is_submenu = false; apagar.action = MenuAction::POWEROFF;
 


### PR DESCRIPTION
## Summary
- add MUSIC_MENU action to menu controller
- instantiate AudioPlayer and MusicMenu in screen node
- route button events and drawing to MusicMenu so tracks can play

## Testing
- `\colcon build 2>&1 | head -n 200`
- `\colcon test 2>&1 | head -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68bee8216cd483219abd3cfe8de00004