### PR TITLE
Ensure simulation canvas matches eye dimensions

### DIFF
--- a/src/screen/Display.cpp
+++ b/src/screen/Display.cpp
@@ -56,7 +56,7 @@ private:
   std::string title_;
   int scale_{6};
   int w_{0}, h_{0};             // opcional, si el usuario fuerza
-  int last_w_{128}, last_h_{64}; // recordado del último frame
+  int last_w_{0}, last_h_{0};   // recordado del último frame (0 = desconocido)
   bool window_ready_{false};
 };
 

--- a/src/screen/EyesUnifiedNode.cpp
+++ b/src/screen/EyesUnifiedNode.cpp
@@ -216,8 +216,8 @@ int main(int argc, char** argv){
   RCLCPP_INFO(log, "Eyes+Menu @ %d FPS, backend=%s, display=%dx%d, eyes=%dx%d",
               fps, backend.c_str(), display->width(), display->height(), eyes_w, eyes_h);
 
-  int DW = display->width();   if(DW <= 0) DW = eyes_w;
-  int DH = display->height();  if(DH <= 0) DH = eyes_h;
+  int DW = std::max(display->width(), eyes_w);
+  int DH = std::max(display->height(), eyes_h);
   double font_scale = std::clamp(DH / 200.0, 0.1, 1.0);
   menu.setFontScale(font_scale);
   music_menu.setFontScale(font_scale);


### PR DESCRIPTION
## Summary
- Initialize DisplaySim dimensions to zero so eyes frame sets size on first update
- Use max of display and eye dimensions for simulation canvas to avoid clipping

## Testing
- `\colcon build 2>&1 | head -n 200`
- `\colcon test 2>&1 | head -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68beeb3288b4832189771bc3f5a21ce1