### PR TITLE
Improve AudioPlayer command detection

### DIFF
--- a/include/robofer/audio/AudioPlayer.hpp
+++ b/include/robofer/audio/AudioPlayer.hpp
@@ -110,6 +110,17 @@ private:
    */
   bool spawnPlayer(const std::string& filepath);
 
+  /**
+   * @brief Check whether an executable is available in PATH.
+   */
+  bool commandExists(const std::string& name) const;
+
+  /**
+   * @brief Build the command line used to play the provided file.
+   */
+  std::optional<std::vector<std::string>> buildPlayerCommand(
+      const std::string& filepath, bool is_wav, bool is_mp3) const;
+
   std::vector<std::string> paths_;
   std::vector<std::string> exts_;
   std::unordered_map<std::string, std::string> index_;

--- a/src/audio/AudioPlayer.cpp
+++ b/src/audio/AudioPlayer.cpp
@@ -89,6 +89,13 @@ bool AudioPlayer::spawnPlayer(const std::string& filepath){
     return false;
   }
 
+  auto command = buildPlayerCommand(filepath, is_wav, is_mp3);
+  if(!command){
+    std::cerr << "[AudioPlayer] No se encontró reproductor compatible en el PATH."
+              << " Instala 'aplay', 'mpg123', 'ffmpeg' o 'ffplay'.\n";
+    return false;
+  }
+
   stop();
 
   child_pid_ = fork();
@@ -99,20 +106,14 @@ bool AudioPlayer::spawnPlayer(const std::string& filepath){
   }
 
   if(child_pid_ == 0){
-    if(is_wav){
-      if(alsa_dev_.empty()){
-        execlp("aplay", "aplay", filepath.c_str(), (char*)nullptr);
-      }else{
-        execlp("aplay", "aplay", "-D", alsa_dev_.c_str(), filepath.c_str(), (char*)nullptr);
-      }
-    } else {
-      if(alsa_dev_.empty()){
-        execlp("mpg123", "mpg123", filepath.c_str(), (char*)nullptr);
-      } else {
-        execlp("mpg123", "mpg123", "-a", alsa_dev_.c_str(), filepath.c_str(), (char*)nullptr);
-      }
+    std::vector<char*> argv;
+    argv.reserve(command->size() + 1);
+    for(auto& arg : *command){
+      argv.push_back(const_cast<char*>(arg.c_str()));
     }
-    std::perror("execlp");
+    argv.push_back(nullptr);
+    execvp(argv[0], argv.data());
+    std::perror("execvp");
     _exit(127);
   }
 
@@ -193,6 +194,11 @@ std::vector<std::string> AudioPlayer::listTracks() const {
 double AudioPlayer::getDuration(const std::string& key_or_path){
   auto resolved = resolveKeyOrPath(key_or_path);
   if(!resolved) return -1.0;
+  if(!commandExists("ffprobe")){
+    std::cerr << "[AudioPlayer] ffprobe no disponible, duración desconocida para "
+              << *resolved << "\n";
+    return -1.0;
+  }
   std::string cmd = std::string("ffprobe -v error -show_entries format=duration -of "
                                "default=noprint_wrappers=1:nokey=1 \"") +
                     *resolved + "\"";
@@ -202,6 +208,71 @@ double AudioPlayer::getDuration(const std::string& key_or_path){
   if(!fgets(buf, sizeof(buf), fp)){ pclose(fp); return -1.0; }
   pclose(fp);
   return std::atof(buf);
+}
+
+bool AudioPlayer::commandExists(const std::string& name) const{
+  if(name.empty()) return false;
+  if(name.find('/') != std::string::npos){
+    return access(name.c_str(), X_OK) == 0;
+  }
+  const char* path_env = std::getenv("PATH");
+  if(!path_env) return false;
+  std::string path(path_env);
+  size_t start = 0;
+  while(start <= path.size()){
+    size_t end = path.find(':', start);
+    std::string dir = path.substr(start, (end == std::string::npos) ? std::string::npos : end - start);
+    if(dir.empty()) dir = ".";
+    fs::path candidate = fs::path(dir) / name;
+    if(access(candidate.c_str(), X_OK) == 0){
+      return true;
+    }
+    if(end == std::string::npos) break;
+    start = end + 1;
+  }
+  return false;
+}
+
+std::optional<std::vector<std::string>> AudioPlayer::buildPlayerCommand(
+    const std::string& filepath, bool is_wav, bool is_mp3) const{
+  const std::string device = alsa_dev_;
+
+  if(is_wav && commandExists("aplay")){
+    std::vector<std::string> cmd = {"aplay"};
+    if(!device.empty()){
+      cmd.push_back("-D");
+      cmd.push_back(device);
+    }
+    cmd.push_back(filepath);
+    return cmd;
+  }
+
+  if(is_mp3 && commandExists("mpg123")){
+    std::vector<std::string> cmd = {"mpg123"};
+    if(!device.empty()){
+      cmd.push_back("-a");
+      cmd.push_back(device);
+    }
+    cmd.push_back(filepath);
+    return cmd;
+  }
+
+  if(commandExists("ffmpeg")){
+    std::vector<std::string> cmd = {
+        "ffmpeg", "-nostdin", "-hide_banner", "-loglevel", "error",
+        "-i", filepath, "-f", "alsa",
+        device.empty() ? "default" : device};
+    return cmd;
+  }
+
+  if(commandExists("ffplay")){
+    std::vector<std::string> cmd = {
+        "ffplay", "-autoexit", "-nodisp", "-hide_banner", "-loglevel", "error",
+        filepath};
+    return cmd;
+  }
+
+  return std::nullopt;
 }
 
 } // namespace robo_audio


### PR DESCRIPTION
## Summary
- add runtime checks before launching the audio player process so missing binaries are reported cleanly
- build playback commands dynamically with fallbacks for wav/mp3 files and reuse them for execvp
- guard duration probing when ffprobe is unavailable to avoid runtime errors

## Testing
- bash -lc 'set -eo pipefail; source /opt/ros/jazzy/setup.bash; export PATH="$(printf "%s" "$PATH" | tr ':' "\n" | grep -v -E "\\.pyenv/shims" | paste -sd: -)"; hash -r; which python3; python3 -V; python3 -c "import em"; \\colcon build 2>&1 | head -n 200' *(fails: command not found: \colcon)*

------
https://chatgpt.com/codex/tasks/task_e_6901f108aab08321bc033016e7507517