### PR TITLE
Add Puxaine mode with looping playlist and dancing eyes

### DIFF
--- a/include/robofer/control/StateHandler.hpp
+++ b/include/robofer/control/StateHandler.hpp
@@ -53,10 +53,12 @@ private:
   class HappyState;
   class AngryState;
   class SadState;
+  class PuxaineState;
 
   friend class HappyState;
   friend class AngryState;
   friend class SadState;
+  friend class PuxaineState;
 
   /**
    * @brief Change the active mood/state.

--- a/include/robofer/screen/Eyes.hpp
+++ b/include/robofer/screen/Eyes.hpp
@@ -22,7 +22,7 @@ constexpr int BGCOLOR = 0;   /**< Background/overlays. */
 constexpr int MAINCOLOR = 255; /**< Drawings. */
 
 /** Mood presets used to adjust eye expression */
-enum Mood : uint8_t { DEFAULT = 0, TIRED = 1, ANGRY = 2, HAPPY = 3, FROWN = 4 };
+enum Mood : uint8_t { DEFAULT = 0, TIRED = 1, ANGRY = 2, HAPPY = 3, FROWN = 4, BAILONGO = 5 };
 
 /** Predefined gaze positions */
 enum Pos : uint8_t { CENTER=0, N=1, NE=2, E=3, SE=4, S=5, SW=6, W=7, NW=8 };
@@ -348,6 +348,7 @@ private:
   // mood flags
   bool tired_=false, angry_=false, happy_=false;
   bool frown_=false; // <— ceño fruncido
+  bool bailongo_=false;
   bool curious_=false; // outer eye grows when looking sideways
   bool cyclops_=false; // single eye
   bool eyeL_open_=false, eyeR_open_=false;
@@ -397,6 +398,12 @@ private:
   bool idle_=false; int idleInterval_s_=1, idleVar_s_=3; uint64_t idleTimer_=0;
   bool confused_=false; uint64_t confusedTimer_=0; int confusedDur_ms_=500; bool confusedToggle_=true;
   bool laugh_=false; uint64_t laughTimer_=0; int laughDur_ms_=500; bool laughToggle_=true;
+
+  double bailongo_phase_=0.0;
+  uint64_t bailongo_last_ms_=0;
+  int bailongo_h_amp_=0;
+  int bailongo_v_amp_=0;
+  int bailongo_space_amp_=0;
 
   // RNG
   std::mt19937 rng_;

--- a/include/robofer/screen/UiMenu.hpp
+++ b/include/robofer/screen/UiMenu.hpp
@@ -21,6 +21,7 @@ enum class MenuAction {
   SET_ANGRY,
   SET_SAD,
   SET_HAPPY,
+  SET_PUXAINE,
   POWEROFF,
   BT_CONNECT,
   BT_ACCEPT,

--- a/src/control/StateHandler.cpp
+++ b/src/control/StateHandler.cpp
@@ -1,10 +1,17 @@
 #include <functional>
 #include <chrono>
+#include <filesystem>
+#include <algorithm>
+#include <cctype>
+#include <vector>
+#include <cstdlib>
 #include "robofer/control/StateHandler.hpp"
 
 using namespace std::chrono_literals;
 
 namespace robofer {
+
+namespace fs = std::filesystem;
 
 // --- State implementations -------------------------------------------------
 
@@ -44,6 +51,98 @@ public:
     ctx.servos_.setIdle(1);
     if(ctx.audio_ && !ctx.sad_sound_.empty())
       ctx.audio_->play(ctx.sad_sound_);
+  }
+};
+
+class StateHandler::PuxaineState : public StateHandler::State {
+public:
+  void onEnter(StateHandler &ctx) override {
+    RCLCPP_INFO(ctx.get_logger(), "Entering PUXAINE state");
+    std_msgs::msg::UInt8 msg; msg.data = static_cast<uint8_t>(Mood::BAILONGO);
+    ctx.mood_pub_->publish(msg);
+    ctx.servos_.setSpeed(0, 360.0f);
+    ctx.servos_.setSpeed(1,-360.0f);
+    loadPlaylist(ctx);
+    if(playlist_.empty()){
+      RCLCPP_WARN(ctx.get_logger(),
+                  "Modo Puxaine: no se encontraron pistas en %s",
+                  root_dir_.empty() ? "(desconocido)" : root_dir_.c_str());
+      return;
+    }
+    current_index_ = 0;
+    if(!startCurrent(ctx)){
+      advance(ctx);
+    }
+  }
+
+  void onUpdate(StateHandler &ctx) override {
+    if(playlist_.empty() || !ctx.audio_) return;
+    if(ctx.audio_->isPlaying()) return;
+    advance(ctx);
+  }
+
+  void onExit(StateHandler &ctx) override {
+    (void)ctx;
+    playlist_.clear();
+  }
+
+private:
+  std::vector<std::string> playlist_;
+  size_t current_index_{0};
+  std::string root_dir_;
+
+  static std::string toLower(const std::string& s){
+    std::string out(s);
+    std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
+    return out;
+  }
+
+  void loadPlaylist(StateHandler &ctx){
+    playlist_.clear();
+    root_dir_.clear();
+    const char* home = std::getenv("HOME");
+    if(!home){
+      RCLCPP_WARN(ctx.get_logger(), "Modo Puxaine: variable HOME no definida");
+      return;
+    }
+    fs::path dir = fs::path(home) / "Music" / "Pux";
+    root_dir_ = dir.string();
+    std::error_code ec;
+    if(!fs::exists(dir, ec) || !fs::is_directory(dir, ec)){
+      RCLCPP_WARN(ctx.get_logger(), "Modo Puxaine: directorio inexistente: %s", root_dir_.c_str());
+      return;
+    }
+
+    static const std::vector<std::string> kExts{".wav", ".mp3"};
+    for(fs::recursive_directory_iterator it(dir, ec), end; it != end; it.increment(ec)){
+      if(ec){ ec.clear(); continue; }
+      if(!it->is_regular_file()) continue;
+      std::string ext = toLower(it->path().extension().string());
+      if(std::find(kExts.begin(), kExts.end(), ext) == kExts.end()) continue;
+      playlist_.push_back(it->path().string());
+    }
+    std::sort(playlist_.begin(), playlist_.end());
+  }
+
+  bool startCurrent(StateHandler &ctx){
+    if(!ctx.audio_ || playlist_.empty()) return false;
+    const std::string& track = playlist_[current_index_];
+    if(ctx.audio_->play(track)){
+      RCLCPP_INFO(ctx.get_logger(), "Modo Puxaine: reproduciendo %s", track.c_str());
+      return true;
+    }
+    RCLCPP_WARN(ctx.get_logger(), "Modo Puxaine: no se pudo reproducir %s", track.c_str());
+    return false;
+  }
+
+  void advance(StateHandler &ctx){
+    if(playlist_.empty()) return;
+    size_t attempts = playlist_.size();
+    while(attempts-- > 0){
+      current_index_ = (current_index_ + 1) % playlist_.size();
+      if(startCurrent(ctx)) return;
+    }
+    RCLCPP_WARN(ctx.get_logger(), "Modo Puxaine: ninguna pista reproducible disponible");
   }
 };
 
@@ -97,6 +196,9 @@ void StateHandler::setState(Mood m) {
       break;
     case Mood::ANGRY:
       current_state_ = std::make_unique<AngryState>();
+      break;
+    case Mood::BAILONGO:
+      current_state_ = std::make_unique<PuxaineState>();
       break;
     case Mood::FROWN:
     default:

--- a/src/screen/Eyes.cpp
+++ b/src/screen/Eyes.cpp
@@ -1,6 +1,7 @@
 #include "robofer/screen/Eyes.hpp"
 #include <opencv2/imgproc.hpp>
 #include <algorithm>
+#include <cmath>
 
 using namespace robo_eyes;
 
@@ -57,6 +58,11 @@ void RoboEyes::begin(int w, int h, int fps){
   idleTimer_  = now + idleInterval_s_*1000  + rnd(std::max(0, idleVar_s_))*1000;
 
   fps_timer_ms_ = now;
+  bailongo_phase_ = 0.0;
+  bailongo_last_ms_ = 0;
+  bailongo_h_amp_ = std::max(2, screenConstraintX()/4);
+  bailongo_v_amp_ = std::max(2, screenConstraintY()/4);
+  bailongo_space_amp_ = std::max(1, spaceBetweenDefault_/4);
 }
 
 void RoboEyes::setFramerate(int fps){ frame_interval_ms_ = std::max(1, 1000/std::max(1,fps)); }
@@ -70,7 +76,28 @@ void RoboEyes::setBorderRadius(int l, int r){ eyeL_r_next_=eyeL_r_def_=l; eyeR_r
 
 void RoboEyes::setSpaceBetween(int px){ spaceBetweenNext_=spaceBetweenDefault_=px; }
 
-void RoboEyes::setMood(Mood m){ tired_=angry_=happy_=frown_=false; if(m==TIRED) tired_=true; else if(m==ANGRY) angry_=true; else if(m==HAPPY) happy_=true; else if(m==FROWN) frown_=true;}
+void RoboEyes::setMood(Mood m){
+  tired_=angry_=happy_=frown_=false;
+  bailongo_ = false;
+  if(m==TIRED) tired_=true;
+  else if(m==ANGRY) angry_=true;
+  else if(m==HAPPY) happy_=true;
+  else if(m==FROWN) frown_=true;
+  else if(m==BAILONGO){
+    bailongo_=true;
+    happy_=true; // sonrisa mientras baila
+    bailongo_phase_=0.0;
+    bailongo_last_ms_=0;
+    // centra los ojos para comenzar
+    eyeLx_next_=screenConstraintX()/2;
+    eyeLy_next_=screenConstraintY()/2;
+    spaceBetweenNext_=spaceBetweenDefault_;
+  }
+  if(!bailongo_){
+    bailongo_phase_=0.0;
+    bailongo_last_ms_=0;
+  }
+}
 
 void RoboEyes::setPosition(Pos p){
   switch(p){
@@ -281,11 +308,37 @@ void RoboEyes::drawEyes(){
     else if(t >= confusedTimer_ + confusedDur_ms_){ hFlicker_=false; confusedToggle_=true; confused_=false; }
   }
 
-  if(idle_ && !frown_){
+  if(idle_ && !frown_ && !bailongo_){
     if(t >= idleTimer_){
       eyeLx_next_ = rnd(std::max(0, screenConstraintX()));
       eyeLy_next_ = rnd(std::max(0, screenConstraintY()));
       idleTimer_ = t + idleInterval_s_*1000 + rnd(std::max(0, idleVar_s_))*1000;
+    }
+  }
+
+  if(bailongo_){
+    if(bailongo_last_ms_ == 0){
+      bailongo_last_ms_ = t;
+    }
+    double dt = static_cast<double>(t - bailongo_last_ms_) / 1000.0;
+    bailongo_last_ms_ = t;
+    const double speed = 3.5; // radianes por segundo
+    bailongo_phase_ += dt * speed;
+    const double main_phase = bailongo_phase_;
+    const double second_phase = bailongo_phase_ * 1.6;
+    int cx = screenConstraintX()/2;
+    int cy = screenConstraintY()/2;
+    int nx = clampi(cx + static_cast<int>(std::sin(main_phase) * bailongo_h_amp_), 0, screenConstraintX());
+    int ny = clampi(cy + static_cast<int>(std::cos(second_phase) * bailongo_v_amp_), 0, screenConstraintY());
+    int spacing = clampi(spaceBetweenDefault_ + static_cast<int>(std::sin(main_phase*2.0) * bailongo_space_amp_), 4, std::max(4, screenConstraintX()));
+    eyeLx_next_ = nx;
+    eyeLy_next_ = ny;
+    spaceBetweenNext_ = spacing;
+    // alterna pequeños guiños en ritmo
+    constexpr double kPi = 3.14159265358979323846;
+    double blink_phase = std::fmod(bailongo_phase_, kPi);
+    if(blink_phase < 0.15){
+      blinkBoth();
     }
   }
 

--- a/src/screen/EyesNode.cpp
+++ b/src/screen/EyesNode.cpp
@@ -70,6 +70,7 @@ int main(int argc, char** argv){
   if(mood_s=="tired") eyes.setMood(Mood::TIRED);
   else if(mood_s=="angry") eyes.setMood(Mood::ANGRY);
   else if(mood_s=="happy") eyes.setMood(Mood::HAPPY);
+  else if(mood_s=="bailongo" || mood_s=="puxaine") eyes.setMood(Mood::BAILONGO);
   else eyes.setMood(Mood::DEFAULT);
 
   // Abrimos inicialmente (opcional)
@@ -99,6 +100,7 @@ int main(int argc, char** argv){
       case '2': eyes.setMood(Mood::ANGRY);  break;
       case '3': eyes.setMood(Mood::FROWN);  break;
       case '0': eyes.setMood(Mood::DEFAULT);break;
+      case '4': eyes.setMood(Mood::BAILONGO);break;
       case 'i': eyes.setIdle(true);  break;
       case 'I': eyes.setIdle(false); break;
       case 'c': curious=!curious; eyes.setCuriosity(curious); break;

--- a/src/screen/EyesUnifiedNode.cpp
+++ b/src/screen/EyesUnifiedNode.cpp
@@ -102,6 +102,11 @@ int main(int argc, char** argv){
         mode_pub->publish(m);
         RCLCPP_INFO(log, "MenuAction -> mode HAPPY");
         break;
+      case MenuAction::SET_PUXAINE:
+        m.data = static_cast<uint8_t>(Mood::BAILONGO);
+        mode_pub->publish(m);
+        RCLCPP_INFO(log, "MenuAction -> mode PUXAINE");
+        break;
       case MenuAction::POWEROFF:
         RCLCPP_WARN(log, "MenuAction: POWEROFF (llamando a sudo poweroff)");
         std::system("sudo poweroff &");

--- a/src/screen/UiMenu.cpp
+++ b/src/screen/UiMenu.cpp
@@ -12,6 +12,7 @@ MenuController::Item MenuController::buildDefaultTree(){
   modos.children.push_back({"Angry", false, MenuAction::SET_ANGRY, {}});
   modos.children.push_back({"Sad",   false, MenuAction::SET_SAD,   {}});
   modos.children.push_back({"Happy", false, MenuAction::SET_HAPPY, {}});
+  modos.children.push_back({"Puxaine", false, MenuAction::SET_PUXAINE, {}});
 
   Item wifi; wifi.label = "Wi-Fi"; wifi.is_submenu = true;
   wifi.children.push_back({"Status: --", false, MenuAction::NONE, {}});


### PR DESCRIPTION
## Summary
- add the new Puxaine mood with a bailongo eye animation and supporting state logic
- loop through audio tracks inside `~/Music/Pux` while the new mode is active
- surface the Puxaine option through the UI menu and simulator node shortcuts

## Testing
- \colcon build 2>&1 | head -n 200
- \colcon test 2>&1 | head -n 200

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6903891533b88321ba4f9f88e63e62fb)