### PR TITLE
Add love mood with heart eyes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ desde la última pulsación.
   * Angry → cambia humor a ANGRY
   * Sad → cambia a FROWN ("triste/ceño")
   * Happy → cambia a HAPPY
+  * Love → cambia a LOVE (ojos con corazones)
 * Wi-Fi → vacío por ahora (placeholder).
 * Apagar → ejecuta `sudo poweroff`.
 

--- a/include/robofer/control/StateHandler.hpp
+++ b/include/robofer/control/StateHandler.hpp
@@ -53,10 +53,12 @@ private:
   class HappyState;
   class AngryState;
   class SadState;
+  class LoveState;
 
   friend class HappyState;
   friend class AngryState;
   friend class SadState;
+  friend class LoveState;
 
   /**
    * @brief Change the active mood/state.
@@ -80,6 +82,7 @@ private:
   std::string happy_sound_;
   std::string angry_sound_;
   std::string sad_sound_;
+  std::string love_sound_;
   rclcpp::Publisher<std_msgs::msg::UInt8>::SharedPtr mood_pub_;
   rclcpp::Subscription<std_msgs::msg::UInt8>::SharedPtr mode_sub_;
   rclcpp::TimerBase::SharedPtr timer_;

--- a/include/robofer/screen/Eyes.hpp
+++ b/include/robofer/screen/Eyes.hpp
@@ -22,7 +22,7 @@ constexpr int BGCOLOR = 0;   /**< Background/overlays. */
 constexpr int MAINCOLOR = 255; /**< Drawings. */
 
 /** Mood presets used to adjust eye expression */
-enum Mood : uint8_t { DEFAULT = 0, TIRED = 1, ANGRY = 2, HAPPY = 3, FROWN = 4 };
+enum Mood : uint8_t { DEFAULT = 0, TIRED = 1, ANGRY = 2, HAPPY = 3, FROWN = 4, LOVE = 5 };
 
 /** Predefined gaze positions */
 enum Pos : uint8_t { CENTER=0, N=1, NE=2, E=3, SE=4, S=5, SW=6, W=7, NW=8 };
@@ -330,6 +330,13 @@ private:
    * @param gray Gray value.
    */
   static void fillCircle(cv::Mat& img, int cx, int cy, int r, int gray);
+  /**
+   * @brief Draw a stylised filled heart.
+   * @param img Target image.
+   * @param roi Bounding box for the heart.
+   * @param gray Gray value.
+   */
+  static void fillHeart(cv::Mat& img, cv::Rect roi, int gray);
 
   /**
    * @brief Render the eyes into the internal canvas.
@@ -348,6 +355,7 @@ private:
   // mood flags
   bool tired_=false, angry_=false, happy_=false;
   bool frown_=false; // <— ceño fruncido
+  bool love_=false;  // <— ojos en modo corazón
   bool curious_=false; // outer eye grows when looking sideways
   bool cyclops_=false; // single eye
   bool eyeL_open_=false, eyeR_open_=false;

--- a/include/robofer/screen/UiMenu.hpp
+++ b/include/robofer/screen/UiMenu.hpp
@@ -21,6 +21,7 @@ enum class MenuAction {
   SET_ANGRY,
   SET_SAD,
   SET_HAPPY,
+  SET_LOVE,
   POWEROFF,
   BT_CONNECT,
   BT_ACCEPT,

--- a/src/control/StateHandler.cpp
+++ b/src/control/StateHandler.cpp
@@ -47,6 +47,19 @@ public:
   }
 };
 
+class StateHandler::LoveState : public StateHandler::State {
+public:
+  void onEnter(StateHandler &ctx) override {
+    RCLCPP_INFO(ctx.get_logger(), "Entering LOVE state");
+    std_msgs::msg::UInt8 msg; msg.data = static_cast<uint8_t>(Mood::LOVE);
+    ctx.mood_pub_->publish(msg);
+    ctx.servos_.moveTo(0, 90.0f, 60.0f);
+    ctx.servos_.moveTo(1, 90.0f, 60.0f);
+    if(ctx.audio_ && !ctx.love_sound_.empty())
+      ctx.audio_->play(ctx.love_sound_);
+  }
+};
+
 } // namespace robofer
 
 using robofer::StateHandler;
@@ -68,6 +81,7 @@ StateHandler::StateHandler()
   happy_sound_ = declare_parameter<std::string>("happy_sound", "");
   angry_sound_ = declare_parameter<std::string>("angry_sound", "");
   sad_sound_ = declare_parameter<std::string>("sad_sound", "");
+  love_sound_ = declare_parameter<std::string>("love_sound", "");
   RCLCPP_INFO(get_logger(), "State handler starting (sim=%s)", sim ? "true" : "false");
   mood_pub_ = create_publisher<std_msgs::msg::UInt8>("/eyes/mood", 10);
   mode_sub_ = create_subscription<std_msgs::msg::UInt8>(
@@ -97,6 +111,9 @@ void StateHandler::setState(Mood m) {
       break;
     case Mood::ANGRY:
       current_state_ = std::make_unique<AngryState>();
+      break;
+    case Mood::LOVE:
+      current_state_ = std::make_unique<LoveState>();
       break;
     case Mood::FROWN:
     default:

--- a/src/screen/Eyes.cpp
+++ b/src/screen/Eyes.cpp
@@ -70,7 +70,33 @@ void RoboEyes::setBorderRadius(int l, int r){ eyeL_r_next_=eyeL_r_def_=l; eyeR_r
 
 void RoboEyes::setSpaceBetween(int px){ spaceBetweenNext_=spaceBetweenDefault_=px; }
 
-void RoboEyes::setMood(Mood m){ tired_=angry_=happy_=frown_=false; if(m==TIRED) tired_=true; else if(m==ANGRY) angry_=true; else if(m==HAPPY) happy_=true; else if(m==FROWN) frown_=true;}
+void RoboEyes::setMood(Mood m){
+  tired_=angry_=happy_=frown_=love_=false;
+  switch(m){
+    case Mood::TIRED:
+      tired_ = true;
+      break;
+    case Mood::ANGRY:
+      angry_ = true;
+      break;
+    case Mood::HAPPY:
+      happy_ = true;
+      break;
+    case Mood::FROWN:
+      frown_ = true;
+      break;
+    case Mood::LOVE:
+      love_ = true;
+      eyeL_open_ = eyeR_open_ = true;
+      eyeL_h_next_ = eyeL_h_def_;
+      eyeR_h_next_ = eyeR_h_def_;
+      spaceBetweenNext_ = spaceBetweenDefault_;
+      break;
+    case Mood::DEFAULT:
+    default:
+      break;
+  }
+}
 
 void RoboEyes::setPosition(Pos p){
   switch(p){
@@ -105,7 +131,33 @@ void RoboEyes::fillRect(cv::Mat& img, int x, int y, int w, int h, int gray){
   if(w<=0||h<=0) return; cv::rectangle(img, cv::Rect(x,y,w,h), cv::Scalar(gray), cv::FILLED, cv::LINE_8);
 }
 
-void RoboEyes::fillCircle(cv::Mat& img, int cx, int cy, int r, int gray){ if(r>0) cv::circle(img, {cx,cy}, r, cv::Scalar(gray), cv::FILLED, cv::LINE_8); }
+void RoboEyes::fillCircle(cv::Mat& img, int cx, int cy, int r, int gray){
+  if(r>0) cv::circle(img, {cx,cy}, r, cv::Scalar(gray), cv::FILLED, cv::LINE_8);
+}
+
+void RoboEyes::fillHeart(cv::Mat& img, cv::Rect roi, int gray){
+  if(roi.width <= 0 || roi.height <= 0) return;
+  cv::Rect bounds(0, 0, img.cols, img.rows);
+  cv::Rect safe = roi & bounds;
+  if(safe.width <= 0 || safe.height <= 0) return;
+
+  cv::Mat mask(roi.height, roi.width, CV_8UC1, cv::Scalar(0));
+  int w = mask.cols;
+  int h = mask.rows;
+  int radius = std::max(1, std::min(w, h) / 4);
+
+  cv::Point left(w/2 - radius, h/3);
+  cv::Point right(w/2 + radius, h/3);
+  cv::circle(mask, left, radius, cv::Scalar(255), cv::FILLED, cv::LINE_8);
+  cv::circle(mask, right, radius, cv::Scalar(255), cv::FILLED, cv::LINE_8);
+
+  std::vector<cv::Point> tri{{0, h/3}, {w-1, h/3}, {w/2, h-1}};
+  cv::fillConvexPoly(mask, tri, cv::Scalar(255), cv::LINE_8);
+
+  cv::Rect inner(safe.x - roi.x, safe.y - roi.y, safe.width, safe.height);
+  cv::Mat mask_roi = mask(inner);
+  img(safe).setTo(cv::Scalar(gray), mask_roi);
+}
 
 void RoboEyes::fillRoundRect(cv::Mat& img, int x, int y, int w, int h, int r, int gray){
   if(w<=0||h<=0) return;
@@ -317,6 +369,21 @@ void RoboEyes::drawEyes(){
 
   // Draw
   clear(canvas_, BGCOLOR);
+  if(love_){
+    int padL = std::max(1, std::min(eyeL_w_cur_, eyeL_h_cur_) / 6);
+    cv::Rect roiL(eyeLx_ + padL, eyeLy_ + padL,
+                  std::max(0, eyeL_w_cur_ - 2*padL),
+                  std::max(0, eyeL_h_cur_ - 2*padL));
+    fillHeart(canvas_, roiL, MAINCOLOR);
+    if(!cyclops_ && eyeR_w_cur_ > 0 && eyeR_h_cur_ > 0){
+      int padR = std::max(1, std::min(eyeR_w_cur_, eyeR_h_cur_) / 6);
+      cv::Rect roiR(eyeRx_ + padR, eyeRy_ + padR,
+                    std::max(0, eyeR_w_cur_ - 2*padR),
+                    std::max(0, eyeR_h_cur_ - 2*padR));
+      fillHeart(canvas_, roiR, MAINCOLOR);
+    }
+    return;
+  }
   // if (frown_) {
 
   //   eyeLx_next_ = screenConstraintX() / 2;

--- a/src/screen/Eyes.cpp
+++ b/src/screen/Eyes.cpp
@@ -1,6 +1,7 @@
 #include "robofer/screen/Eyes.hpp"
 #include <opencv2/imgproc.hpp>
 #include <algorithm>
+#include <cmath>
 
 using namespace robo_eyes;
 
@@ -90,12 +91,16 @@ void RoboEyes::setMood(Mood m){
       eyeL_open_ = eyeR_open_ = true;
       eyeL_h_next_ = eyeL_h_def_;
       eyeR_h_next_ = eyeR_h_def_;
-      spaceBetweenNext_ = spaceBetweenDefault_;
+      // ojos más juntos en modo LOVE
+      spaceBetweenNext_ = std::max(1, spaceBetweenDefault_/2);
       break;
     case Mood::DEFAULT:
     default:
+      // resto de modos: separación normal
+      spaceBetweenNext_ = spaceBetweenDefault_;
       break;
   }
+  setAutoblinker(!love_);
 }
 
 void RoboEyes::setPosition(Pos p){
@@ -141,22 +146,66 @@ void RoboEyes::fillHeart(cv::Mat& img, cv::Rect roi, int gray){
   cv::Rect safe = roi & bounds;
   if(safe.width <= 0 || safe.height <= 0) return;
 
-  cv::Mat mask(roi.height, roi.width, CV_8UC1, cv::Scalar(0));
-  int w = mask.cols;
-  int h = mask.rows;
-  int radius = std::max(1, std::min(w, h) / 4);
+  constexpr double PI = 3.14159265358979323846;
+  double time = static_cast<double>(now_ms() % 1600) / 1600.0;
+  double pulse = std::sin(time * 2.0 * PI); // [-1,1], mismo en ambos ojos
 
-  cv::Point left(w/2 - radius, h/3);
-  cv::Point right(w/2 + radius, h/3);
-  cv::circle(mask, left, radius, cv::Scalar(255), cv::FILLED, cv::LINE_8);
-  cv::circle(mask, right, radius, cv::Scalar(255), cv::FILLED, cv::LINE_8);
+  int w = safe.width;
+  int h = safe.height;
+  if(w <= 3 || h <= 3) return;
 
-  std::vector<cv::Point> tri{{0, h/3}, {w-1, h/3}, {w/2, h-1}};
-  cv::fillConvexPoly(mask, tri, cv::Scalar(255), cv::LINE_8);
+  // margen muy pequeño: corazones casi ocupan toda la celda
+  int margin = std::max(1, std::min(w,h) / 14);
+  int w0 = std::max(2, w - 2*margin);
+  int h0 = std::max(2, h - 2*margin);
 
-  cv::Rect inner(safe.x - roi.x, safe.y - roi.y, safe.width, safe.height);
-  cv::Mat mask_roi = mask(inner);
-  img(safe).setTo(cv::Scalar(gray), mask_roi);
+  // escala del latido: siempre <= 1.0 para no tocar bordes
+  double base_scale = 0.95;
+  double amp = 0.05;
+  double scale = base_scale + amp * pulse;          // ~[0.90,1.00]
+  double scale_x = scale;
+  double scale_y = scale;
+
+  cv::Mat mask = cv::Mat::zeros(h, w, CV_8UC1);
+  for(int y=0; y<h0; ++y){
+    double ny = (1.6 - 3.2 * static_cast<double>(y) / (h0 - 1)) / scale_y;
+    for(int x=0; x<w0; ++x){
+      double nx = ((2.0 * static_cast<double>(x) / (w0 - 1)) - 1.0) / scale_x;
+      double value = std::pow(nx*nx + ny*ny - 1.0, 3.0) - nx*nx*ny*ny*ny;
+      if(value <= 0.0){
+        mask.at<uint8_t>(margin + y, margin + x) = 255;
+      }
+    }
+  }
+
+  cv::Mat outer = mask.clone();
+  int border_px = std::max(1, std::min(w, h) / 10);
+  cv::Mat kernel = cv::getStructuringElement(cv::MORPH_ELLIPSE,
+                                             cv::Size(border_px*2+1, border_px*2+1));
+  cv::Mat inner;
+  cv::erode(outer, inner, kernel);
+  cv::Mat border;
+  cv::subtract(outer, inner, border);
+
+  cv::Mat highlight = cv::Mat::zeros(h, w, CV_8UC1);
+  int highlight_h = std::max(1, h0 / 3);
+  cv::Rect highlight_roi(margin, margin, w0, highlight_h);
+  if(highlight_roi.width > 0 && highlight_roi.height > 0){
+    outer(highlight_roi).copyTo(highlight(highlight_roi));
+  }
+
+  int inner_tone = std::clamp(gray, 0, 255);
+  int border_tone = std::clamp(gray - 110, 0, 255);
+  int highlight_tone = std::clamp(gray + 60, 0, 255);
+
+  cv::Rect slice(safe.x - roi.x, safe.y - roi.y, safe.width, safe.height);
+  cv::Mat border_mask = border(slice);
+  cv::Mat highlight_mask = highlight(slice);
+  cv::Mat outer_mask = outer(slice);
+
+  img(safe).setTo(cv::Scalar(inner_tone), outer_mask);
+  img(safe).setTo(cv::Scalar(highlight_tone), highlight_mask);
+  img(safe).setTo(cv::Scalar(border_tone), border_mask);
 }
 
 void RoboEyes::fillRoundRect(cv::Mat& img, int x, int y, int w, int h, int r, int gray){
@@ -370,13 +419,13 @@ void RoboEyes::drawEyes(){
   // Draw
   clear(canvas_, BGCOLOR);
   if(love_){
-    int padL = std::max(1, std::min(eyeL_w_cur_, eyeL_h_cur_) / 6);
+    int padL = std::max(1, std::min(eyeL_w_cur_, eyeL_h_cur_) / 12);
     cv::Rect roiL(eyeLx_ + padL, eyeLy_ + padL,
                   std::max(0, eyeL_w_cur_ - 2*padL),
                   std::max(0, eyeL_h_cur_ - 2*padL));
     fillHeart(canvas_, roiL, MAINCOLOR);
     if(!cyclops_ && eyeR_w_cur_ > 0 && eyeR_h_cur_ > 0){
-      int padR = std::max(1, std::min(eyeR_w_cur_, eyeR_h_cur_) / 6);
+      int padR = std::max(1, std::min(eyeR_w_cur_, eyeR_h_cur_) / 12);
       cv::Rect roiR(eyeRx_ + padR, eyeRy_ + padR,
                     std::max(0, eyeR_w_cur_ - 2*padR),
                     std::max(0, eyeR_h_cur_ - 2*padR));
@@ -427,8 +476,38 @@ void RoboEyes::drawEyes(){
   return;
   }
   // base eyes
-  fillRoundRect(canvas_, eyeLx_, eyeLy_, eyeL_w_cur_, eyeL_h_cur_, eyeL_r_cur_, MAINCOLOR);
-  if(!cyclops_) fillRoundRect(canvas_, eyeRx_, eyeRy_, eyeR_w_cur_, eyeR_h_cur_, eyeR_r_cur_, MAINCOLOR);
+  if(love_){
+    cv::Scalar inner(235);
+    cv::Scalar border(80);
+    cv::Scalar highlight(255);
+    auto draw_love_eye = [&](int x, int y, int w, int h, int border_px){
+      cv::Rect outer_roi(x, y, w, h);
+      fillRoundRect(canvas_, outer_roi.x, outer_roi.y, outer_roi.width, outer_roi.height,
+                    std::max(4, std::min(outer_roi.width, outer_roi.height)/2), border[0]);
+      cv::Rect inner_roi = outer_roi;
+      inner_roi.x += border_px;
+      inner_roi.y += border_px;
+      inner_roi.width -= border_px*2;
+      inner_roi.height -= border_px*2;
+      if(inner_roi.width > 0 && inner_roi.height > 0){
+        fillRoundRect(canvas_, inner_roi.x, inner_roi.y, inner_roi.width, inner_roi.height,
+                      std::max(4, std::min(inner_roi.width, inner_roi.height)/2), inner[0]);
+        cv::Rect top_half(inner_roi.x, inner_roi.y,
+                          inner_roi.width, std::max(1, inner_roi.height/3));
+        fillRoundRect(canvas_, top_half.x, top_half.y, top_half.width, top_half.height,
+                      std::max(2, std::min(top_half.width, top_half.height)/2), highlight[0]);
+      }
+    };
+    int border_px = std::max(2, std::min(eyeL_w_cur_, eyeL_h_cur_) / 6);
+    draw_love_eye(eyeLx_, eyeLy_, eyeL_w_cur_, eyeL_h_cur_, border_px);
+    if(!cyclops_ && eyeR_w_cur_ > 0 && eyeR_h_cur_ > 0){
+      border_px = std::max(2, std::min(eyeR_w_cur_, eyeR_h_cur_) / 6);
+      draw_love_eye(eyeRx_, eyeRy_, eyeR_w_cur_, eyeR_h_cur_, border_px);
+    }
+  } else {
+    fillRoundRect(canvas_, eyeLx_, eyeLy_, eyeL_w_cur_, eyeL_h_cur_, eyeL_r_cur_, MAINCOLOR);
+    if(!cyclops_) fillRoundRect(canvas_, eyeRx_, eyeRy_, eyeR_w_cur_, eyeR_h_cur_, eyeR_r_cur_, MAINCOLOR);
+  }
 
   // mood transitions
   eyelidsTiredH_next_ = tired_ ? eyeL_h_cur_/2 : 0;

--- a/src/screen/EyesNode.cpp
+++ b/src/screen/EyesNode.cpp
@@ -70,6 +70,7 @@ int main(int argc, char** argv){
   if(mood_s=="tired") eyes.setMood(Mood::TIRED);
   else if(mood_s=="angry") eyes.setMood(Mood::ANGRY);
   else if(mood_s=="happy") eyes.setMood(Mood::HAPPY);
+  else if(mood_s=="love") eyes.setMood(Mood::LOVE);
   else eyes.setMood(Mood::DEFAULT);
 
   // Abrimos inicialmente (opcional)
@@ -98,6 +99,7 @@ int main(int argc, char** argv){
       case '1': eyes.setMood(Mood::TIRED);  break;
       case '2': eyes.setMood(Mood::ANGRY);  break;
       case '3': eyes.setMood(Mood::FROWN);  break;
+      case '4': eyes.setMood(Mood::LOVE);   break;
       case '0': eyes.setMood(Mood::DEFAULT);break;
       case 'i': eyes.setIdle(true);  break;
       case 'I': eyes.setIdle(false); break;

--- a/src/screen/EyesUnifiedNode.cpp
+++ b/src/screen/EyesUnifiedNode.cpp
@@ -5,6 +5,7 @@
 #include <std_srvs/srv/set_bool.hpp>
 #include <cstdlib>
 #include <regex>
+#include <atomic>
 #include "robofer/bluetoothctl_agent.hpp"
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
@@ -68,6 +69,7 @@ int main(int argc, char** argv){
   audio_player.reindex();
   robo_ui::MusicMenu music_menu(audio_player);
   bool music_mode = false;
+  std::atomic<Mood> current_mood{Mood::DEFAULT};
 
   auto update_bt_menu = [&](){
     if(!menu_ptr) return;
@@ -214,7 +216,9 @@ int main(int argc, char** argv){
   auto sub_mood = node->create_subscription<std_msgs::msg::UInt8>(
     "/eyes/mood", 10,
     [&](const std_msgs::msg::UInt8::SharedPtr msg){
-      eyes.setMood(static_cast<Mood>(msg->data));
+      Mood m = static_cast<Mood>(msg->data);
+      current_mood.store(m, std::memory_order_relaxed);
+      eyes.setMood(m);
     });
 
   rclcpp::Rate rate(fps);
@@ -263,7 +267,14 @@ int main(int argc, char** argv){
     cv::Rect roi(ox, oy, std::min(m.cols, DW-ox), std::min(m.rows, DH-oy));
     if(roi.width > 0 && roi.height > 0){
       cv::Mat src = m(cv::Rect(0,0,roi.width,roi.height));
-      cv::cvtColor(src, canvas(roi), cv::COLOR_GRAY2BGR);
+      cv::Mat dst = canvas(roi);
+      cv::cvtColor(src, dst, cv::COLOR_GRAY2BGR);
+      if(current_mood.load(std::memory_order_relaxed) == Mood::LOVE){
+        cv::Mat mask;
+        cv::threshold(src, mask, 1, 255, cv::THRESH_BINARY);
+        cv::Mat pink(dst.size(), CV_8UC3, cv::Scalar(170, 120, 200));
+        pink.copyTo(dst, mask);
+      }
     }
 
     {
@@ -282,4 +293,3 @@ int main(int argc, char** argv){
   rclcpp::shutdown();
   return 0;
 }
-

--- a/src/screen/EyesUnifiedNode.cpp
+++ b/src/screen/EyesUnifiedNode.cpp
@@ -102,6 +102,11 @@ int main(int argc, char** argv){
         mode_pub->publish(m);
         RCLCPP_INFO(log, "MenuAction -> mode HAPPY");
         break;
+      case MenuAction::SET_LOVE:
+        m.data = static_cast<uint8_t>(Mood::LOVE);
+        mode_pub->publish(m);
+        RCLCPP_INFO(log, "MenuAction -> mode LOVE");
+        break;
       case MenuAction::POWEROFF:
         RCLCPP_WARN(log, "MenuAction: POWEROFF (llamando a sudo poweroff)");
         std::system("sudo poweroff &");

--- a/src/screen/UiMenu.cpp
+++ b/src/screen/UiMenu.cpp
@@ -12,6 +12,7 @@ MenuController::Item MenuController::buildDefaultTree(){
   modos.children.push_back({"Angry", false, MenuAction::SET_ANGRY, {}});
   modos.children.push_back({"Sad",   false, MenuAction::SET_SAD,   {}});
   modos.children.push_back({"Happy", false, MenuAction::SET_HAPPY, {}});
+  modos.children.push_back({"Love",  false, MenuAction::SET_LOVE,  {}});
 
   Item wifi; wifi.label = "Wi-Fi"; wifi.is_submenu = true;
   wifi.children.push_back({"Status: --", false, MenuAction::NONE, {}});


### PR DESCRIPTION
## Summary
- add a LOVE mood for RoboEyes that renders heart-shaped pupils and exposes a fillHeart helper
- extend StateHandler, menu actions, and nodes so the new mood can be requested and toggled from ROS or the UI
- document the new love mode entry in the README

## Testing
- `\colcon build 2>&1 | head -n 200` *(fails: command hung while streaming output)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69038a52ecd083219a1510dca65be1e8)