### PR TITLE
Add Puxaine dance mode with looping playlist

### DIFF
--- a/include/robofer/audio/AudioPlayer.hpp
+++ b/include/robofer/audio/AudioPlayer.hpp
@@ -82,6 +82,13 @@ public:
   std::vector<std::string> listTracks() const;
 
   /**
+   * @brief Check whether the provided path has a supported extension.
+   * @param path File path to check.
+   * @return true if the file extension is playable.
+   */
+  bool isSupportedFile(const std::string& path) const;
+
+  /**
    * @brief Get duration of an audio file in seconds if possible.
    * @param key_or_path Key or path to the audio file.
    * @return Duration in seconds or negative on failure.

--- a/include/robofer/control/StateHandler.hpp
+++ b/include/robofer/control/StateHandler.hpp
@@ -57,6 +57,7 @@ private:
   class LoveState;
   class BailoteoState;
   class BailoteoWaitingState;
+  class PuxaineState;
 
   friend class HappyState;
   friend class AngryState;
@@ -64,6 +65,7 @@ private:
   friend class LoveState;
   friend class BailoteoState;
   friend class BailoteoWaitingState;
+  friend class PuxaineState;
 
   /**
    * @brief Change the active mood/state.

--- a/include/robofer/screen/Eyes.hpp
+++ b/include/robofer/screen/Eyes.hpp
@@ -31,7 +31,8 @@ enum Mood : uint8_t {
   FROWN = 4,
   BAILOTEO_WAIT = 5,
   BAILOTEO = 6,
-  LOVE = 7
+  LOVE = 7,
+  PUXAINE = 8
 };
 
 /** Predefined gaze positions */

--- a/include/robofer/screen/UiMenu.hpp
+++ b/include/robofer/screen/UiMenu.hpp
@@ -21,6 +21,7 @@ enum class MenuAction {
   SET_ANGRY,
   SET_SAD,
   SET_HAPPY,
+  SET_PUXAINE,
   SET_LOVE,
   POWEROFF,
   BT_CONNECT,

--- a/src/audio/AudioPlayer.cpp
+++ b/src/audio/AudioPlayer.cpp
@@ -302,6 +302,11 @@ std::vector<std::string> AudioPlayer::listTracks() const {
   return keys;
 }
 
+bool AudioPlayer::isSupportedFile(const std::string& path) const {
+  std::string ext = toLower(fs::path(path).extension().string());
+  return std::find(exts_.begin(), exts_.end(), ext) != exts_.end();
+}
+
 double AudioPlayer::getDuration(const std::string& key_or_path){
   auto resolved = resolveKeyOrPath(key_or_path);
   if(!resolved) return -1.0;

--- a/src/control/StateHandler.cpp
+++ b/src/control/StateHandler.cpp
@@ -1,9 +1,15 @@
 #include <functional>
 #include <chrono>
+#include <filesystem>
+#include <string>
+#include <vector>
+#include <cstdlib>
+#include <algorithm>
 #include <std_msgs/msg/bool.hpp>
 #include "robofer/control/StateHandler.hpp"
 
 using namespace std::chrono_literals;
+namespace fs = std::filesystem;
 
 namespace robofer {
 
@@ -105,6 +111,93 @@ private:
   std::chrono::steady_clock::time_point last_switch_{};
 };
 
+class StateHandler::PuxaineState : public StateHandler::State {
+public:
+  void onEnter(StateHandler &ctx) override {
+    RCLCPP_INFO(ctx.get_logger(), "Entering PUXAINE state");
+    bailoteo_.onEnter(ctx);
+    loadPlaylist(ctx);
+    if(playlist_.empty()){
+      RCLCPP_WARN(ctx.get_logger(), "No se encontraron audios en %s", target_dir_.c_str());
+      return;
+    }
+    index_ = 0;
+    if(!startNext(ctx)){
+      RCLCPP_WARN(ctx.get_logger(), "No se pudo iniciar la reproducción en Puxaine");
+    }
+  }
+
+  void onUpdate(StateHandler &ctx) override {
+    bailoteo_.onUpdate(ctx);
+    if(playlist_.empty()) return;
+    if(!ctx.audio_) return;
+    if(ctx.audio_->isPlaying()) return;
+    if(!startNext(ctx)){
+      RCLCPP_WARN(ctx.get_logger(), "No se pudieron reproducir las pistas de Puxaine");
+    }
+  }
+
+  void onExit(StateHandler &ctx) override {
+    bailoteo_.onExit(ctx);
+    if(ctx.audio_) ctx.audio_->stop();
+  }
+
+private:
+  void loadPlaylist(StateHandler &ctx){
+    playlist_.clear();
+    const char* home = std::getenv("HOME");
+    if(!home){
+      RCLCPP_WARN(ctx.get_logger(), "HOME no definido: sin playlist Puxaine");
+      return;
+    }
+
+    target_dir_ = (fs::path(home) / "Music" / "Pux").string();
+    std::error_code ec;
+    fs::path dir(target_dir_);
+    if(!fs::exists(dir, ec) || !fs::is_directory(dir, ec)){
+      RCLCPP_WARN(ctx.get_logger(), "Carpeta Puxaine no encontrada: %s", target_dir_.c_str());
+      return;
+    }
+
+    std::vector<fs::path> files;
+    for(fs::directory_iterator it(dir, ec), end; it != end; it.increment(ec)){
+      if(ec) break;
+      const auto& entry = *it;
+      if(!entry.is_regular_file(ec)) continue;
+      fs::path p = entry.path();
+      if(!ctx.audio_ || !ctx.audio_->isSupportedFile(p.string())) continue;
+      files.push_back(p);
+    }
+
+    std::sort(files.begin(), files.end(), [](const fs::path& a, const fs::path& b){
+      return a.filename().string() < b.filename().string();
+    });
+
+    for(const auto& p : files){
+      auto canonical = fs::canonical(p, ec);
+      if(ec) continue;
+      playlist_.push_back(canonical.string());
+    }
+  }
+
+  bool startNext(StateHandler &ctx){
+    if(!ctx.audio_ || playlist_.empty()) return false;
+
+    for(size_t attempt=0; attempt<playlist_.size(); ++attempt){
+      const std::string& path = playlist_[index_];
+      index_ = (index_ + 1) % playlist_.size();
+      if(ctx.audio_->play(path)) return true;
+      RCLCPP_WARN(ctx.get_logger(), "Fallo al reproducir %s", path.c_str());
+    }
+    return false;
+  }
+
+  std::vector<std::string> playlist_{};
+  size_t index_{0};
+  std::string target_dir_{};
+  BailoteoState bailoteo_{};
+};
+
 } // namespace robofer
 
 using robofer::StateHandler;
@@ -167,6 +260,9 @@ void StateHandler::setState(Mood m) {
       break;
     case Mood::LOVE:
       current_state_ = std::make_unique<LoveState>();
+      break;
+    case Mood::PUXAINE:
+      current_state_ = std::make_unique<PuxaineState>();
       break;
     case Mood::BAILOTEO:
       current_state_ = std::make_unique<BailoteoState>();

--- a/src/screen/Eyes.cpp
+++ b/src/screen/Eyes.cpp
@@ -82,6 +82,7 @@ void RoboEyes::setMood(Mood m){
       break;
     case Mood::HAPPY:
     case Mood::BAILOTEO:
+    case Mood::PUXAINE:
       happy_ = true;
       break;
     case Mood::FROWN:

--- a/src/screen/EyesUnifiedNode.cpp
+++ b/src/screen/EyesUnifiedNode.cpp
@@ -131,6 +131,14 @@ int main(int argc, char** argv){
         update_bailoteo_state();
         RCLCPP_INFO(log, "MenuAction -> mode HAPPY");
         break;
+      case MenuAction::SET_PUXAINE:
+        bailoteo_active = false;
+        bailoteo_playing = false;
+        bailoteo_paused = false;
+        last_regular_mood = Mood::PUXAINE;
+        update_bailoteo_state();
+        RCLCPP_INFO(log, "MenuAction -> mode PUXAINE");
+        break;
       case MenuAction::SET_LOVE: {
         std_msgs::msg::UInt8 msg;
         msg.data = static_cast<uint8_t>(Mood::LOVE);

--- a/src/screen/UiMenu.cpp
+++ b/src/screen/UiMenu.cpp
@@ -12,6 +12,7 @@ MenuController::Item MenuController::buildDefaultTree(){
   modos.children.push_back({"Angry", false, MenuAction::SET_ANGRY, {}});
   modos.children.push_back({"Sad",   false, MenuAction::SET_SAD,   {}});
   modos.children.push_back({"Happy", false, MenuAction::SET_HAPPY, {}});
+  modos.children.push_back({"Puxaine", false, MenuAction::SET_PUXAINE, {}});
   modos.children.push_back({"Love",  false, MenuAction::SET_LOVE,  {}});
 
   Item wifi; wifi.label = "Wi-Fi"; wifi.is_submenu = true;


### PR DESCRIPTION
## Summary
- add the Puxaine mode entry to the UI and mood enum
- implement a Puxaine state that loops audio from ~/Music/Pux with dancing eyes
- expose audio helpers to detect supported files for playlist building

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933357b36c0832185381bbfdb5c11a1)