### PR TITLE
Add Peo mode with looping audio playlist

### DIFF
--- a/include/robofer/control/StateHandler.hpp
+++ b/include/robofer/control/StateHandler.hpp
@@ -58,6 +58,7 @@ private:
   class BailoteoState;
   class BailoteoWaitingState;
   class PuxaineState;
+  class PeoState;
 
   friend class HappyState;
   friend class AngryState;
@@ -66,6 +67,7 @@ private:
   friend class BailoteoState;
   friend class BailoteoWaitingState;
   friend class PuxaineState;
+  friend class PeoState;
 
   /**
    * @brief Change the active mood/state.

--- a/include/robofer/screen/Eyes.hpp
+++ b/include/robofer/screen/Eyes.hpp
@@ -32,7 +32,8 @@ enum Mood : uint8_t {
   BAILOTEO_WAIT = 5,
   BAILOTEO = 6,
   LOVE = 7,
-  PUXAINE = 8
+  PUXAINE = 8,
+  PEO = 9
 };
 
 /** Predefined gaze positions */

--- a/include/robofer/screen/UiMenu.hpp
+++ b/include/robofer/screen/UiMenu.hpp
@@ -22,6 +22,7 @@ enum class MenuAction {
   SET_SAD,
   SET_HAPPY,
   SET_PUXAINE,
+  SET_PEO,
   SET_LOVE,
   POWEROFF,
   BT_CONNECT,
@@ -185,4 +186,3 @@ private:
 };
 
 } // namespace robo_ui
-

--- a/src/control/StateHandler.cpp
+++ b/src/control/StateHandler.cpp
@@ -231,6 +231,94 @@ private:
   BailoteoState bailoteo_{};
 };
 
+class StateHandler::PeoState : public StateHandler::State {
+public:
+  void onEnter(StateHandler &ctx) override {
+    RCLCPP_INFO(ctx.get_logger(), "Entering PEO state");
+    ctx.publishMood(Mood::PEO);
+    ctx.publishIdle(true);
+    ctx.publishEyePos(robo_eyes::Pos::CENTER);
+    ctx.servos_.setIdle(0);
+    ctx.servos_.setIdle(1);
+    loadPlaylist(ctx);
+    if(playlist_.empty()){
+      RCLCPP_WARN(ctx.get_logger(), "No se encontraron audios en %s", target_dir_.c_str());
+      return;
+    }
+    index_ = 0;
+    if(!startNext(ctx)){
+      RCLCPP_WARN(ctx.get_logger(), "No se pudo iniciar la reproducción en Peo");
+    }
+  }
+
+  void onUpdate(StateHandler &ctx) override {
+    if(playlist_.empty()) return;
+    if(!ctx.audio_) return;
+    if(ctx.audio_->isPlaying()) return;
+    if(!startNext(ctx)){
+      RCLCPP_WARN(ctx.get_logger(), "No se pudieron reproducir las pistas de Peo");
+    }
+  }
+
+  void onExit(StateHandler &ctx) override {
+    if(ctx.audio_) ctx.audio_->stop();
+  }
+
+private:
+  void loadPlaylist(StateHandler &ctx){
+    playlist_.clear();
+    const char* home = std::getenv("HOME");
+    if(!home){
+      RCLCPP_WARN(ctx.get_logger(), "HOME no definido: sin playlist Peo");
+      return;
+    }
+
+    target_dir_ = (fs::path(home) / "Music" / "Peo").string();
+    std::error_code ec;
+    fs::path dir(target_dir_);
+    if(!fs::exists(dir, ec) || !fs::is_directory(dir, ec)){
+      RCLCPP_WARN(ctx.get_logger(), "Carpeta Peo no encontrada: %s", target_dir_.c_str());
+      return;
+    }
+
+    std::vector<fs::path> files;
+    for(fs::directory_iterator it(dir, ec), end; it != end; it.increment(ec)){
+      if(ec) break;
+      const auto& entry = *it;
+      if(!entry.is_regular_file(ec)) continue;
+      fs::path p = entry.path();
+      if(!ctx.audio_ || !ctx.audio_->isSupportedFile(p.string())) continue;
+      files.push_back(p);
+    }
+
+    std::sort(files.begin(), files.end(), [](const fs::path& a, const fs::path& b){
+      return a.filename().string() < b.filename().string();
+    });
+
+    for(const auto& p : files){
+      auto canonical = fs::canonical(p, ec);
+      if(ec) continue;
+      playlist_.push_back(canonical.string());
+    }
+  }
+
+  bool startNext(StateHandler &ctx){
+    if(!ctx.audio_ || playlist_.empty()) return false;
+
+    for(size_t attempt=0; attempt<playlist_.size(); ++attempt){
+      const std::string& path = playlist_[index_];
+      index_ = (index_ + 1) % playlist_.size();
+      if(ctx.audio_->play(path)) return true;
+      RCLCPP_WARN(ctx.get_logger(), "Fallo al reproducir %s", path.c_str());
+    }
+    return false;
+  }
+
+  std::vector<std::string> playlist_{};
+  size_t index_{0};
+  std::string target_dir_{};
+};
+
 } // namespace robofer
 
 using robofer::StateHandler;
@@ -300,6 +388,9 @@ void StateHandler::setState(Mood m) {
       break;
     case Mood::PUXAINE:
       current_state_ = std::make_unique<PuxaineState>();
+      break;
+    case Mood::PEO:
+      current_state_ = std::make_unique<PeoState>();
       break;
     case Mood::BAILOTEO:
       current_state_ = std::make_unique<BailoteoState>();

--- a/src/screen/Eyes.cpp
+++ b/src/screen/Eyes.cpp
@@ -87,6 +87,7 @@ void RoboEyes::setMood(Mood m){
       break;
     case Mood::FROWN:
     case Mood::BAILOTEO_WAIT:
+    case Mood::PEO:
       frown_ = true;
       break;
     case Mood::LOVE:

--- a/src/screen/EyesNode.cpp
+++ b/src/screen/EyesNode.cpp
@@ -71,6 +71,7 @@ int main(int argc, char** argv){
   else if(mood_s=="angry") eyes.setMood(Mood::ANGRY);
   else if(mood_s=="happy") eyes.setMood(Mood::HAPPY);
   else if(mood_s=="love") eyes.setMood(Mood::LOVE);
+  else if(mood_s=="peo") eyes.setMood(Mood::PEO);
   else eyes.setMood(Mood::DEFAULT);
 
   // Abrimos inicialmente (opcional)
@@ -100,6 +101,7 @@ int main(int argc, char** argv){
       case '2': eyes.setMood(Mood::ANGRY);  break;
       case '3': eyes.setMood(Mood::FROWN);  break;
       case '4': eyes.setMood(Mood::LOVE);   break;
+      case '5': eyes.setMood(Mood::PEO);    break;
       case '0': eyes.setMood(Mood::DEFAULT);break;
       case 'i': eyes.setIdle(true);  break;
       case 'I': eyes.setIdle(false); break;

--- a/src/screen/EyesUnifiedNode.cpp
+++ b/src/screen/EyesUnifiedNode.cpp
@@ -139,6 +139,11 @@ int main(int argc, char** argv){
         update_bailoteo_state();
         RCLCPP_INFO(log, "MenuAction -> mode PUXAINE");
         break;
+      case MenuAction::SET_PEO:
+        last_regular_mood = Mood::PEO;
+        update_bailoteo_state();
+        RCLCPP_INFO(log, "MenuAction -> mode PEO");
+        break;
       case MenuAction::SET_LOVE: {
         std_msgs::msg::UInt8 msg;
         msg.data = static_cast<uint8_t>(Mood::LOVE);

--- a/src/screen/UiMenu.cpp
+++ b/src/screen/UiMenu.cpp
@@ -13,6 +13,7 @@ MenuController::Item MenuController::buildDefaultTree(){
   modos.children.push_back({"Sad",   false, MenuAction::SET_SAD,   {}});
   modos.children.push_back({"Happy", false, MenuAction::SET_HAPPY, {}});
   modos.children.push_back({"Puxaine", false, MenuAction::SET_PUXAINE, {}});
+  modos.children.push_back({"Peo", false, MenuAction::SET_PEO, {}});
   modos.children.push_back({"Love",  false, MenuAction::SET_LOVE,  {}});
 
   Item wifi; wifi.label = "Wi-Fi"; wifi.is_submenu = true;
@@ -295,4 +296,3 @@ void MenuController::drawItems(cv::Mat& img, const std::vector<Item>& items, int
 }
 
 } // namespace robo_ui
-


### PR DESCRIPTION
### Motivation
- Añadir un nuevo modo "Peo" que muestre la misma expresión ocular que `Sad/Frown` (los ojos tipo `><`) y que reproduzca en bucle los contenidos de `~/Music/Peo`.
- Permitir activar el modo desde el menú y desde el simulador para integrarlo con la UI existente.
- Reutilizar el subsistema de audio existente para gestionar la reproducción de la carpeta específica.

### Description
- Se añadió `Mood::PEO` al enum de `include/robofer/screen/Eyes.hpp` y en `RoboEyes::setMood` se trata `PEO` igual que `FROWN` para la expresión ocular.
- Se introdujo `MenuAction::SET_PEO` y la entrada de menú "Peo" en `src/screen/UiMenu.cpp`, y se añadió el manejo en `src/screen/EyesUnifiedNode.cpp` para publicar el modo; además se añadió el atajo de teclado `'5'` en `src/screen/EyesNode.cpp` para el simulador.
- Se implementó la clase `PeoState` en `src/control/StateHandler.cpp` que carga los archivos desde `~/Music/Peo`, crea una playlist ordenada y reproduce las pistas en bucle usando `robo_audio::AudioPlayer`, y se conectó en `StateHandler::setState`.
- Se actualizaron las declaraciones y amistades en `include/robofer/control/StateHandler.hpp` y se añadieron las inclusiones / wiring necesarios para que el nuevo estado funcione con el resto del sistema.

### Testing
- No se ejecutaron pruebas automáticas para este cambio (no se corrió `\colcon build` ni `\colcon test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948550cf20483219b3faf50b05e0aad)